### PR TITLE
Remove shell prompts from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Scripts to help when working with data files for the portal are made available i
 
 To get set up to use these scripts:
 ```
-$ git clone https://github.com/broadinstitute/single_cell_portal.git
-$ cd single_cell_portal
-$ python3 -m venv env --copies
-$ source env/bin/activate
-$ pip install -r requirements.txt
+git clone https://github.com/broadinstitute/single_cell_portal.git
+cd single_cell_portal
+python3 -m venv env --copies
+source env/bin/activate
+pip install -r requirements.txt
 ```
 
 ## Reporting Bugs and Improvements


### PR DESCRIPTION
Hi there, really minor edit (might be applicable in other places, I haven't checked). 

Having shell prompts in the instructions prevent users from directly copying the commands into a terminal. It can be indicated before the code block what environment the commands should be executed in.

It's obviously a matter of taste but I found myself strongly agreeing with [this post on the topic](https://yihui.name/en/2013/01/code-pollution-with-command-prompts/)