### PR TITLE
Support study file upload via CLI and Python library

### DIFF
--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -209,7 +209,7 @@ print(vars(parsed_args))
 print("-----Args")
 
 env_origin_map = {
-    'development': 'http://localhost',
+    'development': 'https://localhost',
     'production': 'https://portals.broadinstitute.org'
 }
 origin = env_origin_map[parsed_args.environment]

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -143,7 +143,6 @@ parser_permissions.add_argument(
     help='Access to give the user.  Must be one of the following values: '+" ".join(scp_api.c_PERMISSIONS)
 )
 
-'''
 ## Create cluster file upload subparser
 parser_upload_cluster = subargs.add_parser(c_TOOL_CLUSTER,
     help="Upload a cluster file. \""+args.prog+" "+c_TOOL_CLUSTER+" -h\" for more details")
@@ -203,7 +202,6 @@ parser_upload_metadata.add_argument(
     '--file', dest='metadata_file', required=True,
     help='Metadata file to load.'
 )
-'''
 
 parsed_args = args.parse_args()
 print("Args----")
@@ -247,11 +245,11 @@ if hasattr(parsed_args, "permission"):
                                     access=parsed_args.permission,
                                     dry_run=parsed_args.dry_run)
     manage_call_return(ret)
-'''
+
 ## Validate files
 if parsed_args.validate and not hasattr(parsed_args, "summarize_list"):
     print("VALIDATE FILES")
-    command = ["verify_portal_file.py"]
+    command = ["python3 verify_portal_file.py"]
 
     if hasattr(parsed_args, "cluster_file"):
         command.extend(["--coordinates-file", parsed_args.cluster_file])
@@ -284,7 +282,7 @@ if hasattr(parsed_args, "cluster_file"):
                                     z=parsed_args.z_label,
                                     dry_run=parsed_args.dry_run)
     manage_call_return(ret)
-'''
+
 ## Upload metadata file
 ### TODO
 

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -216,6 +216,15 @@ parser_upload_metadata.add_argument(
     '--file', dest='metadata_file', required=True,
     help='Metadata file to load.'
 )
+parser_upload_metadata.add_argument(
+    '--study-name', dest='study_name', required=True,
+    help='Name of the study to add the file.'
+)
+parser_upload_metadata.add_argument(
+    '--description', dest='description',
+    default='',
+    help='Text describing the metadata file.'
+)
 
 parsed_args = args.parse_args()
 print("Args----")
@@ -296,10 +305,15 @@ if hasattr(parsed_args, "cluster_file"):
     manage_call_return(ret)
 
 ## Upload metadata file
-### TODO
+if hasattr(parsed_args, "metadata_file"):
+    print("UPLOAD METADATA FILE")
+    connection = login(manager=connection, dry_run=parsed_args.dry_run)
+    ret = connection.upload_metadata(file=parsed_args.metadata_file,
+                                    study_name=parsed_args.study_name,
+                                    dry_run=parsed_args.dry_run)
+    manage_call_return(ret)
 
 ## Upload expression file
-## Upload cluster file
 if hasattr(parsed_args, "expression_file"):
     print("UPLOAD EXPRESSION FILE")
     connection = login(manager=connection, dry_run=parsed_args.dry_run)

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -68,7 +68,6 @@ def login(manager=None, dry_run=False, api_base=None):
                       api_base=api_base)
     return(manager)
 
-
 args = argparse.ArgumentParser(
     prog='manage_study.py',
     description=__doc__,
@@ -155,21 +154,13 @@ parser_upload_cluster.add_argument(
     help='Name of the study to add the file.'
 )
 parser_upload_cluster.add_argument(
-    '--cluster-name', dest='cluster_name', required=True,
-    help='Name of the clustering that will be used to refer to the plot.'
-)
-parser_upload_cluster.add_argument(
-    '--species', dest='species', required=True,
-    help='Species from which the data is generated.'
-)
-parser_upload_cluster.add_argument(
-    '--genome', dest='genome', required=True,
-    help='Genome assembly used to generate the data.'
-)
-parser_upload_cluster.add_argument(
-    '--description', dest='cluster_description',
+    '--description', dest='description',
     default="Coordinates and optional metadata to visualize clusters.",
     help='Text describing the cluster file.'
+)
+parser_upload_cluster.add_argument(
+    '--cluster-name', dest='cluster_name', required=True,
+    help='Name of the clustering that will be used to refer to the plot.'
 )
 parser_upload_cluster.add_argument(
     '--x', dest='x_label',
@@ -194,6 +185,29 @@ parser_upload_expression.add_argument(
     '--file', dest='expression_file', required=True,
     help='Expression file to load.'
 )
+parser_upload_expression.add_argument(
+    '--study-name', dest='study_name', required=True,
+    help='Name of the study to add the file.'
+)
+parser_upload_expression.add_argument(
+    '--description', dest='description',
+    default='Gene expression in cells',
+    help='Text describing the gene expression matrix file.'
+)
+parser_upload_expression.add_argument(
+    '--species', dest='species', required=True,
+    help='Species from which the data is generated.'
+)
+parser_upload_expression.add_argument(
+    '--genome', dest='genome', required=True,
+    help='Genome assembly used to generate the data.'
+)
+# TODO: Add upstream support for this in SCP RESI API
+# parser_upload_expression.add_argument(
+#     '--axis_label', dest='axis_label',
+#     default='',
+#     help=''
+# )
 
 ## Create metadata file upload subparser
 parser_upload_metadata = subargs.add_parser(c_TOOL_METADATA,
@@ -275,8 +289,6 @@ if hasattr(parsed_args, "cluster_file"):
                                     study_name=parsed_args.study_name,
                                     cluster_name=parsed_args.cluster_name,
                                     description=parsed_args.cluster_description,
-                                    species=parsed_args.species,
-                                    genome=parsed_args.genome,
                                     x=parsed_args.x_label,
                                     y=parsed_args.y_label,
                                     z=parsed_args.z_label,
@@ -287,7 +299,16 @@ if hasattr(parsed_args, "cluster_file"):
 ### TODO
 
 ## Upload expression file
-### TODO
+## Upload cluster file
+if hasattr(parsed_args, "expression_file"):
+    print("UPLOAD EXPRESSION FILE")
+    connection = login(manager=connection, dry_run=parsed_args.dry_run)
+    ret = connection.upload_expression_matrix(file=parsed_args.expression_file,
+                                    study_name=parsed_args.study_name,
+                                    species=parsed_args.species,
+                                    genome=parsed_args.genome,
+                                    dry_run=parsed_args.dry_run)
+    manage_call_return(ret)
 
 ## Upload miscellaneous file
 ### TODO

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -261,7 +261,9 @@ class SCPAPIManager(APIManager):
         self.studies = None
         self.name_to_id = None
         self.bucket_id = None
-        self.species_genomes = {"cat":["felis_catus_9.0","felis_catus_8.0","felis_catus-6.2"]}
+
+        # TODO: Hit the taxons API endpoint to get the list of available species.
+        # self.species_genomes = {"cat":["felis_catus_9.0","felis_catus_8.0","felis_catus-6.2"]}
 
     @staticmethod
     def describe_status_code(status_code):
@@ -291,20 +293,21 @@ class SCPAPIManager(APIManager):
         }
         return(ret_status_codes.get(status_code, "That status code is not in use."))
 
+    '''
     def check_species_genome(self, species, genome=None):
-        '''
-        The SCP only support certain species, this checks the submitted species to make sure it is supported.
+        """The SCP only support certain species, this checks the submitted species to make sure it is supported.
 
         :param species: String species to confirm is supported.
         :param genome: String, if provided optionally checks genome version.
         :return: Boolean, false indicates not supported.
-        '''
+        """
 
         print("CHECK SPECIES (GENOME)")
         if not species.lower() in self.species_genomes:
             print(species+" : this species is not registered with the portal please email the team to have it added.")
             return(False)
         return(genome in self.species_genomes[species])
+    '''
 
     def get_studies(self, dry_run=False):
         '''

--- a/scripts/tests/test_scp_api.py
+++ b/scripts/tests/test_scp_api.py
@@ -30,7 +30,10 @@ class SCPAPITestCase(unittest.TestCase):
 
     @patch('requests.get', side_effect=mocked_requests_get)
     def test_get_studies(self, mock_get):
-        studies = scp_api.SCPAPIManager().get_studies()['studies']
+        manager = scp_api.SCPAPIManager()
+        manager.api_base = 'https://portals.broadinstitute.org/single_cell/api/v1/'
+        manager.verify_https = True
+        studies = manager.get_studies()['studies']
         expected_studies = [
             " Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)",
             "Study only for unit test"


### PR DESCRIPTION
This enables users of Single Cell Portal's command-line interface (`manage_scp.py`) to upload core study files, i.e. expression matrices, metadata files, and cluster files.  In addition to tailored CLI submodules for those specific file types, the related Python library (`scp_api.py`) now has generic support for uploading any type of study file.  These changes improve the developer experience for the SCP REST API.

The CLI provides examples of how to use the Python library.

Usage examples for this new CLI functionality are below.  Note that these all require a local SCP instance with loaded species metadata, a study named "apitest", and the prerequisites described atop `manage_scp.py`.

Upload an expression matrix:
```
python manage_study.py --env development --token=`gcloud auth print-access-token` upload-expression --file ../demo_data/expression_matrix_example.txt --study-name apitest --species "Felis catus" --genome "Felis_catus_9.0"
```

Upload a metadata file:
```
python manage_study.py --env development --token=`gcloud auth print-access-token` upload-metadata --file ../demo_data/metadata_example.txt --study-name apitest
```

Upload a cluster file:
```
python manage_study.py --env development --token=`gcloud auth print-access-token` upload-cluster --file ../demo_data/coordinates_example.txt --study apitest --cluster-name test-cluster`
```

The new `--env` parameter shown above enables local functional testing of these new write operations.

In subsequent work, I would like to provide tailored CLI support for other study file tests, as well as automated tests for these write operations.

Automated tests for read operations pass locally.  See #50 for prior work.