### PR TITLE
POC: Ingest loom into firestore and structure zarr into acceptable data format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pandas>=0.16.2
 requests>=2.21.0
+google-cloud-firestore==0.32.1
+loompy==2.0.15
+zarr==2.2.0

--- a/scripts/scratch_ingest/loom_ingest.py
+++ b/scripts/scratch_ingest/loom_ingest.py
@@ -1,0 +1,56 @@
+import numpy as np
+import loompy
+import sys
+import os
+import  pyrebase
+from google.cloud import firestore
+from itertools import islice
+import time
+
+db = firestore.Client()
+
+np.set_printoptions(precision=8, threshold=sys.maxsize, edgeitems=1e9)
+expression_dictionaries= dict()
+loom_file = sys.argv[1]
+loom_file_name = os.path.splitext(loom_file)[0]
+
+ds = loompy.connect(loom_file)
+
+##creating dictoionary
+def map_genes_to_expression_vaues():
+    for (ix, selection, view) in ds.scan(axis=0, batch_size=5000):
+        #Firestore does not know how to store ndArrays
+        exppressions_values = view[:,:].tolist()
+        accessions = view.ra.Accession.tolist()
+        cell_ids = view.ca.CellID.tolist()
+        expression_dictionaries.update(zip(view.ra.Gene.tolist(),zip(accessions, cell_ids, exppressions_values)))
+
+##Returns a subset (500) of dictionaries
+def chunk(data, SIZE=500):
+    it = iter(data)
+    for i in range(0, len(data), SIZE):
+        yield {k:data[k] for k in islice(it, SIZE)}
+
+##Abstract this out
+def add_data_to_firestore(data):
+    batch = db.batch()
+    ##Should only commit 500 writes to avoid contention
+    #Need to measure write speeds and size of uploads
+    for key,val in data.items():
+        doc_ref = db.collection("loom_gene").document(key)
+        batch.set(doc_ref, {
+        'accession': val[0],
+        'file_name' : loom_file,
+        'cells':{
+        'cell_id': val[1],
+        'expression_values': val[2]
+        }
+        })
+    batch.commit()
+    time.sleep(2)
+
+map_genes_to_expression_vaues()
+for genes in chunk(expression_dictionaries):
+    add_data_to_firestore(genes)
+
+ds.close()

--- a/scripts/scratch_ingest/zarr_ingest.py
+++ b/scripts/scratch_ingest/zarr_ingest.py
@@ -1,41 +1,76 @@
-import zarr
-import numpy as np
+"""Command-line interface for ingesting zarr files into firestore
+
+DESCRIPTION
+This CLI maps cell ids to expression values, and gene ids from
+a zarr file and puts them into firestore.
+
+PREREQUISITES
+You must have google cloud firestore installed, authenticated
+and configured.
+
+EXAMPLES
+# Takes zarr file and stores it into firestore
+$ python zarr_ingest.py  200k_subsample_4k_PMBC.zarr
+"""
+
+
 import sys
 import json
 import os
+import time
+from itertools import islice
+
+from google.cloud import firestore
+import zarr
+import numpy as np
 
 
+db = firestore.Client()
+np.set_printoptions(precision=8, threshold=sys.maxsize, edgeitems=1e9)
+expression_matrix = dict()
 
-zarr_file = sys.argv[1]
-zarr_file_name = os.path.splitext(zarr_file)[0]
-##opens zar file and returns zarr.hierarchy.Group
-za = zarr.open(zarr_file, mode='r')
+parser = argparse.ArgumentParser(
+    prog = 'zarr_ingest.py'
+)
+
+parser.add_argument(
+    "zarr_file", default=None,
+    help='Path to loom file'
+)
+
+args = parser.parse_args()
+
+##opens zar file and returns zarr.hierarchy.Group and file name
+def open_file(zarr_file):
+    return zarr.open(zarr_file, mode='r'), os.path.splitext(zarr_file)[0]
 
 #map expression values to genes
-expression_matrix= dict(zip(za['expression_matrix']['gene_id'][:].tolist(), za['expression_matrix']['expression'][:].tolist()))
-
-##save to zar file in js
-with open('zarr.json', 'w') as outfile:
-    json.dump(expression_matrix, outfile)
+def map_cell_ids_to_expression_values():
+    expression_matrix.update(dict(zip(za['expression_matrix']['cell_id'][0:1000].tolist(), za['expression_matrix']['expression'][0:1000,0:500].tolist())))
 
 ##Save to firestore
 ##Abstract this out
-# def add_data_to_firestore(data):
-#     batch = db.batch()
-#     for key,val in data.items():
-#         doc_ref = db.collection("loom_genes").document(key)
-#         batch.set(doc_ref,
-#         {"expression_valuess":val,
-#         "file_name": zarr_file_name,
-#         "cell_id": za['expression_matrix']['cell_id'][:10]
-#         })
-#     batch.commit()
-#
-# def chunk(data, SIZE=500):
-#     it = iter(data)
-#     for i in range(0, len(data), SIZE):
-#        # if return_data_structure = dictionary:
-#         yield {k:data[k] for k in islice(it, SIZE)}
+def add_data_to_firestore(data):
+    batch = db.batch()
+    for key,val in data.items():
+        exp_val = dict(zip(za['expression_matrix']['gene_id'][0:500].tolist(),val))
+        doc_ref = db.collection("zarr_cells").document(key)
+        batch.set(doc_ref,
+        {
+        "file_name": zarr_file_name,
+        "gene_expression_values":{
+        "expression_values":exp_val
+        }
+        })
+    batch.commit()
+    time.sleep(2)
 
-# for genes in chunk(expression_matrix):
-#     add_data_to_firestore(genes)
+def chunk(data, SIZE=5):
+    it = iter(data)
+    for i in range(0, len(data), SIZE):
+        yield {k:data[k] for k in islice(it, SIZE)}
+
+za, zarr_file_name = open_file(args.zarr_file)
+map_cell_ids_to_expression_values()
+for genes in chunk(expression_matrix):
+    add_data_to_firestore(genes)

--- a/scripts/scratch_ingest/zarr_ingest.py
+++ b/scripts/scratch_ingest/zarr_ingest.py
@@ -1,0 +1,41 @@
+import zarr
+import numpy as np
+import sys
+import json
+import os
+
+
+
+zarr_file = sys.argv[1]
+zarr_file_name = os.path.splitext(zarr_file)[0]
+##opens zar file and returns zarr.hierarchy.Group
+za = zarr.open(zarr_file, mode='r')
+
+#map expression values to genes
+expression_matrix= dict(zip(za['expression_matrix']['gene_id'][:].tolist(), za['expression_matrix']['expression'][:].tolist()))
+
+##save to zar file in js
+with open('zarr.json', 'w') as outfile:
+    json.dump(expression_matrix, outfile)
+
+##Save to firestore
+##Abstract this out
+# def add_data_to_firestore(data):
+#     batch = db.batch()
+#     for key,val in data.items():
+#         doc_ref = db.collection("loom_genes").document(key)
+#         batch.set(doc_ref,
+#         {"expression_valuess":val,
+#         "file_name": zarr_file_name,
+#         "cell_id": za['expression_matrix']['cell_id'][:10]
+#         })
+#     batch.commit()
+#
+# def chunk(data, SIZE=500):
+#     it = iter(data)
+#     for i in range(0, len(data), SIZE):
+#        # if return_data_structure = dictionary:
+#         yield {k:data[k] for k in islice(it, SIZE)}
+
+# for genes in chunk(expression_matrix):
+#     add_data_to_firestore(genes)


### PR DESCRIPTION
This PR will complete [SCP-1561](https://broadinstitute.atlassian.net/browse/SCP-1561) as well as the loom portion of [SCP-1542](https://broadinstitute.atlassian.net/browse/SCP-1542). 
These scripts will run under the condition that Google Firestore has been installed and authorizations/privileges are in order. 

**SCP-1561** 
AC: Convert loom and zarr files into a format that can in ingested into Google cloud Firestore. 
- I was able to take out expression values and gene names from both file formats and save them as json files and store the information into dictionaries. 

**SCP-1542**
AC: Programmatically store both zarr and loom files into Firestore. 
-I was able to upload a loom file of 10k genes (due to writing restrictions on trial account) into Firestore