### PR TITLE
Test CLI upload and parse of cluster file

### DIFF
--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -116,7 +116,7 @@ class APIManager:
 
         if self.verbose: print("BROWSER LOGIN")
         if dry_run:
-            print("DRY_RUN:: Did not login")
+            if self.verbose: print("DRY_RUN:: Did not login")
             return("DRY_RUN_TOKEN")
         cmdline.func_CMD(command="gcloud auth application-default login")
         cmd_ret = cmdline.func_CMD(command="gcloud auth application-default print-access-token",stdout=True)

--- a/scripts/tests/data/study_files_post.json
+++ b/scripts/tests/data/study_files_post.json
@@ -1,1 +1,26 @@
-{"_id":{"$oid":"5d8b6e16421aa90eca8ad4ee"},"parse_status":"unparsed","x_axis_label":"","y_axis_label":"","z_axis_label":"","remote_location":"cluster_example.txt","options":{},"name":"cluster_example.txt","upload_file_name":"cluster_example.txt","upload_content_type":"text/plain","upload_file_size":681,"file_type":"Cluster","generation":"1569418775318853","human_data":false,"queued_for_deletion":false,"study_id":{"$oid":"5d8a8458421aa90eca8ad4d7"},"data_dir":"aff9fefe552d252a7e805240f3733c69586b79350379f0a4f223d61f2b6c0749","updated_at":"2019-09-25T13:39:34.185Z","created_at":"2019-09-25T13:39:34.181Z","status":"uploaded"}
+{
+  "_id": {
+    "$oid": "5d8b6e16421aa90eca8ad4ee"
+  },
+  "parse_status": "unparsed",
+  "x_axis_label": "",
+  "y_axis_label": "",
+  "z_axis_label": "",
+  "remote_location": "cluster_example.txt",
+  "options": {},
+  "name": "cluster_example.txt",
+  "upload_file_name": "cluster_example.txt",
+  "upload_content_type": "text/plain",
+  "upload_file_size": 681,
+  "file_type": "Cluster",
+  "generation": "1569418775318853",
+  "human_data": false,
+  "queued_for_deletion": false,
+  "study_id": {
+    "$oid": "5d8a8458421aa90eca8ad4d7"
+  },
+  "data_dir": "aff9fefe552d252a7e805240f3733c69586b79350379f0a4f223d61f2b6c0749",
+  "updated_at": "2019-09-25T13:39:34.185Z",
+  "created_at": "2019-09-25T13:39:34.181Z",
+  "status": "uploaded"
+}

--- a/scripts/tests/test_scp_api.py
+++ b/scripts/tests/test_scp_api.py
@@ -2,6 +2,7 @@ import requests
 import unittest
 from unittest.mock import patch
 import json
+import re
 
 import sys
 sys.path.append('.')
@@ -9,57 +10,57 @@ sys.path.append('.')
 import scp_api
 
 # TODO: Incorporate into `test_upload_cluster`
-# def mock_upload_via_gsutil(*args, **kwargs):
-#     gsutil_stat = {
-#         'Content-Type': 'test/foo',
-#         'Content-Length': '555',
-#         'Generation': 'foo'
-#     }
-#     filename = 'fake_path.txt'
-#     return [gsutil_stat, filename]
+def mock_upload_via_gsutil(*args, **kwargs):
+    gsutil_stat = {
+        'Content-Type': 'test/foo',
+        'Content-Length': '555',
+        'Generation': 'foo'
+    }
+    filename = 'fake_path.txt'
+    return [gsutil_stat, filename]
 
 # This method will be used by the mock to replace requests.get
 def mocked_requests_get(*args, **kwargs):
     class MockResponse:
-        def __init__(self, json_data, status_code):
+        def __init__(self, json_data, status_code, reason=None):
             self.json_data = json_data
             self.status_code = status_code
+            self.reason = reason
 
         def json(self):
             return self.json_data
     
     url = args[0]
-    if url == 'https://portals.broadinstitute.org/single_cell/api/v1/studies':
+    if url == 'https://singlecell.broadinstitute.org/single_cell/api/v1/studies':
         with open('tests/data/studies.json') as f:
             content = f.read()
         studies_json = json.loads(content, strict=False)
-        return MockResponse(studies_json, 200)
+        return MockResponse(studies_json, 200, reason='OK')
 
     return MockResponse(None, 404)
 
 # This method will be used by the mock to replace requests.post
 def mocked_requests_post(*args, **kwargs):
     class MockResponse:
-        def __init__(self, json_data, status_code):
+        def __init__(self, json_data, status_code, reason=None):
             self.json_data = json_data
             self.status_code = status_code
+            self.reason = reason
 
         def json(self):
             return self.json_data
 
     url = args[0]
-    print('mock post url')
-    print(url)
 
-    study_files_url_re = '/v1/studies/.*/study_files'
-    if re.match(study_files_url_re, url):
+    study_files_url_re = '/v1/studies/.*/study_files$'
+    if re.search(study_files_url_re, url):
         with open('tests/data/study_files_post.json') as f:
             content = f.read()
         study_files_json = json.loads(content, strict=False)
-        return MockResponse(studies_json, 200)
+        return MockResponse(study_files_json, 200, reason='OK')
 
-    parse_url_re = '/v1/studies/.*/study_files/.*/parse'
-    if re.match(parse_url_re, url):
+    parse_url_re = '/v1/studies/.*/study_files/.*/parse$'
+    if re.search(parse_url_re, url):
         return MockResponse(None, 204)
 
     return MockResponse(None, 404)
@@ -69,7 +70,7 @@ class SCPAPITestCase(unittest.TestCase):
     @patch('requests.get', side_effect=mocked_requests_get)
     def test_get_studies(self, mocked_requests_get):
         manager = scp_api.SCPAPIManager()
-        manager.api_base = 'https://portals.broadinstitute.org/single_cell/api/v1/'
+        manager.api_base = 'https://singlecell.broadinstitute.org/single_cell/api/v1/'
         manager.verify_https = True
         studies = manager.get_studies()['studies']
         expected_studies = [
@@ -78,22 +79,23 @@ class SCPAPITestCase(unittest.TestCase):
         ]
         self.assertEqual(studies, expected_studies)
 
-    # TODO: Finish this test per SCP-1897
-    # @patch('scp_api.upload_via_gsutil', side_effect=mock_upload_via_gsutil)
-    # @patch('requests.post', side_effect=mocked_requests_post)
-    # @patch('requests.get', side_effect=mocked_requests_get)
-    # def test_upload_cluster(self, mocked_requests_get, mocked_requests_post, mock_upload_via_gsutil):
-    #     manager = scp_api.SCPAPIManager()
-    #     manager.api_base = 'https://portals.broadinstitute.org/single_cell/api/v1/'
-    #     manager.verify_https = True
-    #     return_object = manager.upload_cluster(file='../tests/data/toy_cluster',
-    #                                 study_name='CLI test',
-    #                                 cluster_name='Test',
-    #                                 description='Test',
-    #                                 x='X', y='Y', z='Z',
-    #                                 dry_run=True)
-    #     print(f'test POST return object: {return_object}')
-    #     # self.assertEqual(studies, expected_studies)
+    @patch('scp_api.SCPAPIManager.upload_via_gsutil', side_effect=mock_upload_via_gsutil)
+    @patch('requests.post', side_effect=mocked_requests_post)
+    @patch('requests.get', side_effect=mocked_requests_get)
+    def test_upload_cluster(self, mocked_requests_get, mocked_requests_post, mock_upload_via_gsutil):
+        # manager = scp_api.SCPAPIManager(verbose=True)
+        manager = scp_api.SCPAPIManager()
+        manager.api_base = 'https://singlecell.broadinstitute.org/single_cell/api/v1/'
+        manager.verify_https = True
+        manager.login(dry_run=True)
+        return_object = manager.upload_cluster(file='../tests/data/toy_cluster',
+                                    study_name='Study only for unit test',
+                                    cluster_name='Test',
+                                    description='Test',
+                                    x='X', y='Y', z='Z')
+        # HTTP 204 indicates successful parse launch, per
+        # https://singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1#!/StudyFiles/parse_study_study_file_path
+        self.assertEqual(return_object['code'], 204)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a narrow integration test for uploading and parsing a cluster file, as implemented in #77.

This satisfies [SCP-1897](https://broadworkbench.atlassian.net/browse/SCP-1897).