### PR TITLE
Enable "staging" environment for public CLI (SCP-2025)

### DIFF
--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -31,6 +31,15 @@ python manage_study.py create-study --help
 
 # Create a study named "CLI test"
 python3 manage_study.py --token=$ACCESS_TOKEN create-study --study-name "CLI test"
+
+# Upload an expression matrix
+python3 manage_study.py --token=$ACCESS_TOKEN upload-expression --file ../demo_data/expression_example.txt --study-name "CLI test" --species "human" --genome "GRCh38"
+
+# Upload a metadata file (without validating against the metadata convention)
+python3 manage_study.py --token=$ACCESS_TOKEN upload-metadata --study-name "CLI test"--file ../demo_data/metadata_example.txt
+
+# Upload a cluster file
+python3 manage_study.py --token=$ACCESS_TOKEN upload-cluster --study-name "${STUDY_NAME}" --file ../demo_data/cluster_example.txt  --cluster-name 'Test cluster' --description test
 """
 
 import argparse

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -160,7 +160,7 @@ args.add_argument(
 args.add_argument(
     '--environment',
     default='production',
-    choices=['development', 'production'],
+    choices=['development', 'staging', 'production'],
     help='API environment to use',
 )
 
@@ -367,6 +367,7 @@ if __name__ == '__main__':
 
     env_origin_map = {
         'development': 'https://localhost',
+        'staging': 'https://single-cell-staging.broadinstitute.org',
         'production': 'https://singlecell.broadinstitute.org',
     }
     origin = env_origin_map[parsed_args.environment]

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -223,33 +223,34 @@ parser_create_studies.add_argument(
     '--is-private', action='store_true', help='Whether the study is private'
 )
 
-## Permissions subparser
-parser_permissions = subargs.add_parser(
-    c_TOOL_PERMISSION,
-    help="Change user permissions in a study. \""
-    + args.prog
-    + " "
-    + c_TOOL_PERMISSION
-    + " -h\" for more details",
-)
-parser_permissions.add_argument(
-    '--email',
-    dest='email',
-    required=True,
-    default='Single Cell Genomics Study',
-    help='User email to update study permission.',
-)
-parser_permissions.add_argument(
-    '--study-name', dest='study_name', required=True, help='Short name of the study.'
-)
-parser_permissions.add_argument(
-    '--access',
-    dest='permission',
-    choices=scp_api.c_PERMISSIONS,
-    required=True,
-    help='Access to give the user.  Must be one of the following values: '
-    + " ".join(scp_api.c_PERMISSIONS),
-)
+# TODO: Fix permissions subparser (SCP-2024)
+# ## Permissions subparser
+# parser_permissions = subargs.add_parser(
+#     c_TOOL_PERMISSION,
+#     help="Change user permissions in a study. \""
+#     + args.prog
+#     + " "
+#     + c_TOOL_PERMISSION
+#     + " -h\" for more details",
+# )
+# parser_permissions.add_argument(
+#     '--email',
+#     dest='email',
+#     required=True,
+#     default='Single Cell Genomics Study',
+#     help='User email to update study permission.',
+# )
+# parser_permissions.add_argument(
+#     '--study-name', dest='study_name', required=True, help='Short name of the study.'
+# )
+# parser_permissions.add_argument(
+#     '--access',
+#     dest='permission',
+#     choices=scp_api.c_PERMISSIONS,
+#     required=True,
+#     help='Access to give the user.  Must be one of the following values: '
+#     + " ".join(scp_api.c_PERMISSIONS),
+# )
 
 ## Create cluster file upload subparser
 parser_upload_cluster = subargs.add_parser(

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -103,7 +103,7 @@ class APIManager:
             token = self.do_browser_login(dry_run=dry_run)
         self.token = token
         self.api_base = api_base
-        self.verify_https = 'https://localhost' not in self.api_base
+        self.verify_https = 'localhost' not in api_base and 'staging' not in api_base
         self.studies = None
 
     def do_browser_login(self, dry_run=False):


### PR DESCRIPTION
This adds a way to use the public CLI on SCP's staging environment, needed as part of developing documentation for `manage_study.py`.

Simply add `--environment staging` to your command, e.g.:
```
python3 manage_study.py --environment staging --token=$ACCESS_TOKEN create-study --study-name="${STUDY_NAME}"
```

Also, other examples have been added, and the problematic "permissions" subparser has been temporarily disabled.

This satisfies SCP-2025.