### PR TITLE
Publish single_cell_portal to PyPI (SCP-2414)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,31 @@
 issues.json
-
-.idea/
-*.pyc
-__pycache__/
-.DS_Store
-scripts/genomes/output/
-.vscode
-scripts/__pycache__
-*.log
-test_output/
-.coverage
-coverage.xml
-output_infercnv_example/
-venv/
-
 scp_validation_errors.txt
 scp_validation_warnings.txt
+scripts/genomes/output/
+output_infercnv_example/
+test_output/
+
+
+# Ignore Python runtime assets
+env/
+venv/
+__pycache__/
+scripts/__pycache__
+*.pyc
+dist
+build
+*egg-info*
+
+# Ignore editor configuration
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.code-workspace
+
+# Ignore other detritus
+*.log
+.DS_Store
+.coverage
+coverage.xml
+htmlcov/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests>=2.21.0
 # Also, if still using this kludge getting and you get failures in CircleCI,
 # then bump cache key in .circleci/config.yml (e.g. v2 -> v3).
 # That's a cost of tech debt until we push to PyPI as proposed above.
-git+git://github.com/broadinstitute/scp-ingest-pipeline@96723ecc15291b8544ed0c9573e76daef291369a#egg=scp-ingest-pipeline
+#git+git://github.com/broadinstitute/scp-ingest-pipeline@96723ecc15291b8544ed0c9573e76daef291369a#egg=scp-ingest-pipeline
 
 # For faster development iterations.
 # ../../scp-ingest-pipeline

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,6 @@
 pandas>=0.16.2
 requests>=2.21.0
-
-# TODO: Publish `scp-ingest-pipeline` to PyPI upon merging that repo to master.
-# PyPI (https://pypi.org) is like NPM or RubyGems, but for Python.
-#
-# Also, if still using this kludge getting and you get failures in CircleCI,
-# then bump cache key in .circleci/config.yml (e.g. v2 -> v3).
-# That's a cost of tech debt until we push to PyPI as proposed above.
-#git+git://github.com/broadinstitute/scp-ingest-pipeline@96723ecc15291b8544ed0c9573e76daef291369a#egg=scp-ingest-pipeline
+scp-ingest-pipeline==1.3.9
 
 # For faster development iterations.
 # ../../scp-ingest-pipeline

--- a/scripts/cli_parser.py
+++ b/scripts/cli_parser.py
@@ -1,5 +1,5 @@
 """"
-CLI for command line arguments for manage_study.py
+CLI for command line arguments for manage-study
 """
 
 import argparse
@@ -11,15 +11,16 @@ c_TOOL_EXPRESSION = "upload-expression"
 c_TOOL_METADATA = "upload-metadata"
 c_TOOL_PERMISSION = "permission"
 c_TOOL_STUDY = "create-study"
-c_TOOL_STUDY_EDIT_DESC= "edit-study-description"
-c_TOOL_STUDY_GET_ATTR= "get-study-attribute"
-c_TOOL_STUDY_GET_EXT= 'get-study-external-resources'
-c_TOOL_STUDY_DEL_EXT= 'delete-study-external-resources'
+c_TOOL_STUDY_EDIT_DESC = "edit-study-description"
+c_TOOL_STUDY_GET_ATTR = "get-study-attribute"
+c_TOOL_STUDY_GET_EXT = 'get-study-external-resources'
+c_TOOL_STUDY_DEL_EXT = 'delete-study-external-resources'
 c_TOOL_STUDY_CREATE_EXT = 'create-study-external-resource'
+
 
 def create_parser():
     args = argparse.ArgumentParser(
-        prog='manage_study.py',
+        prog='manage-study',
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -50,9 +51,8 @@ def create_parser():
         help='API environment to use',
     )
 
-
     # Create tools (subparser)
-    subargs = args.add_subparsers(dest = 'command')
+    subargs = args.add_subparsers(dest='command')
 
     ## List studies subparser
     parser_list_studies = subargs.add_parser(
@@ -89,12 +89,12 @@ def create_parser():
         '--study-name', required=True, help='Short name of the study'
     )
     parser_create_studies.add_argument(
-        '--branding',
-        default=None,
-        help='Portal branding to associate with the study',
+        '--branding', default=None, help='Portal branding to associate with the study',
     )
     parser_create_studies.add_argument(
-        '--billing', default=None, help='Portal billing project to associate with the study'
+        '--billing',
+        default=None,
+        help='Portal billing project to associate with the study',
     )
     parser_create_studies.add_argument(
         '--is-private', action='store_true', help='Whether the study is private'
@@ -197,19 +197,13 @@ def create_parser():
         help='Name of the study to which to add resource.',
     )
     parser_create_ext_resource.add_argument(
-        '--title',
-        required=True,
-        help='Title of resource.',
+        '--title', required=True, help='Title of resource.',
     )
     parser_create_ext_resource.add_argument(
-        '--url',
-        required=True,
-        help='URL of resource.',
+        '--url', required=True, help='URL of resource.',
     )
     parser_create_ext_resource.add_argument(
-        '--description',
-        required=True,
-        help='Tooltip description of resource.',
+        '--description', required=True, help='Tooltip description of resource.',
     )
     parser_create_ext_resource.add_argument(
         '--publication-url',
@@ -258,9 +252,7 @@ def create_parser():
         '--file', dest='cluster_file', required=True, help='Cluster file to load.'
     )
     parser_upload_cluster.add_argument(
-        '--study-name',
-        required=True,
-        help='Name of the study to add the file.',
+        '--study-name', required=True, help='Name of the study to add the file.',
     )
     parser_upload_cluster.add_argument(
         '--description',
@@ -295,9 +287,7 @@ def create_parser():
         '--file', dest='expression_file', required=True, help='Expression file to load.'
     )
     parser_upload_expression.add_argument(
-        '--study-name',
-        required=True,
-        help='Name of the study to add the file.',
+        '--study-name', required=True, help='Name of the study to add the file.',
     )
     parser_upload_expression.add_argument(
         '--description',
@@ -305,14 +295,10 @@ def create_parser():
         help='Text describing the gene expression matrix file.',
     )
     parser_upload_expression.add_argument(
-        '--species',
-        required=True,
-        help='Species from which the data is generated.',
+        '--species', required=True, help='Species from which the data is generated.',
     )
     parser_upload_expression.add_argument(
-        '--genome',
-        required=True,
-        help='Genome assembly used to generate the data.',
+        '--genome', required=True, help='Genome assembly used to generate the data.',
     )
     # TODO: Add upstream support for this in SCP RESI API
     # parser_upload_expression.add_argument(
@@ -336,21 +322,17 @@ def create_parser():
     parser_upload_metadata.add_argument(
         '--use-convention',
         help='Whether to use metadata convention: validates against standard vocabularies, and will enable faceted search on this data',
-        action='store_true'
+        action='store_true',
     )
     parser_upload_metadata.add_argument(
         '--validate-against-convention',
         help='Validates against standard vocabularies prior to upload',
-        action='store_true'
+        action='store_true',
     )
     parser_upload_metadata.add_argument(
-        '--study-name',
-        required=True,
-        help='Name of the study to add the file.',
+        '--study-name', required=True, help='Name of the study to add the file.',
     )
     parser_upload_metadata.add_argument(
-        '--description',
-        default='',
-        help='Text describing the metadata file.',
+        '--description', default='', help='Text describing the metadata file.',
     )
     return args

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -92,12 +92,8 @@ def get_connection():
     return connection
 
 
-def get_parsed_args():
-    return parsed_args
-
-
-def get_api_base():
-    return env_origin_map[get_parsed_args().environment] + '/single_cell/api/v1/'
+def get_api_base(parsed_args):
+    return env_origin_map[parsed_args.environment] + '/single_cell/api/v1/'
 
 
 def manage_call_return(call_return, verbose=False):
@@ -158,10 +154,11 @@ def download_from_bucket(file_path):
     return destination
 
 
-def validate_metadata_file(metadata_path):
-    study_name = get_parsed_args().study_name
-    dry_run = get_parsed_args().dry_run
-    verbose = get_parsed_args().verbose
+def validate_metadata_file(parsed_args):
+    metadata_path = parsed_args.metadata_file
+    study_name = parsed_args.study_name
+    dry_run = parsed_args.dry_run
+    verbose = parsed_args.verbose
     study_accession_res = get_connection().get_study_attribute(
         study_name=study_name, attribute='accession', dry_run=dry_run
     )
@@ -179,7 +176,7 @@ def validate_metadata_file(metadata_path):
             study_accession=str(study_accession),
         )
         convention_res = get_connection().do_get(
-            command=get_api_base()
+            command=get_api_base(parsed_args)
             + 'metadata_schemas/alexandria_convention/latest/json',
             dry_run=dry_run,
         )
@@ -201,7 +198,6 @@ def confirm(question):
 
 
 def main():
-    global parsed_args
     parsed_args = create_parser().parse_args()
     if parsed_args.verbose:
         print("Args----")
@@ -363,7 +359,7 @@ def main():
             print("START VALIDATE FILES")
 
         if hasattr(parsed_args, "metadata_file") and parsed_args.use_convention:
-            validate_metadata_file(parsed_args.metadata_file)
+            validate_metadata_file(parsed_args)
 
         # command = ["python3 verify_portal_file.py"]
         #

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -70,9 +70,16 @@ from ingest.validation.validate_metadata import (
     validate_input_metadata,
 )
 
-import Commandline
-import scp_api
-from cli_parser import *
+try:
+    # Used when importing internally and in tests
+    import Commandline
+    import scp_api
+    from cli_parser import *
+except ImportError:
+    # Used when importing as external package
+    from . import Commandline
+    from . import scp_api
+    from .cli_parser import *
 
 env_origin_map = {
     'development': 'https://localhost',
@@ -80,14 +87,18 @@ env_origin_map = {
     'production': 'https://singlecell.broadinstitute.org',
 }
 
+
 def get_connection():
     return connection
+
 
 def get_parsed_args():
     return parsed_args
 
+
 def get_api_base():
     return env_origin_map[get_parsed_args().environment] + '/single_cell/api/v1/'
+
 
 def manage_call_return(call_return, verbose=False):
     '''
@@ -128,6 +139,7 @@ def login(manager=None, dry_run=False, api_base=None, verbose=False):
         manager.login(token=parsed_args.token, dry_run=dry_run, api_base=api_base)
     return manager
 
+
 def download_from_bucket(file_path):
     """Downloads file from Google Cloud Storage bucket"""
 
@@ -145,14 +157,14 @@ def download_from_bucket(file_path):
 
     return destination
 
+
 def validate_metadata_file(metadata_path):
     study_name = get_parsed_args().study_name
     dry_run = get_parsed_args().dry_run
     verbose = get_parsed_args().verbose
-    study_accession_res =get_connection().get_study_attribute(
-        study_name=study_name,
-        attribute='accession',
-        dry_run=dry_run)
+    study_accession_res = get_connection().get_study_attribute(
+        study_name=study_name, attribute='accession', dry_run=dry_run
+    )
     # Needed dummy values for CellMetadata
     study_file = ObjectId('addedfeed000000000000000')
     study_file_id = ObjectId('addedfeed000000000000001')
@@ -160,9 +172,18 @@ def validate_metadata_file(metadata_path):
         if verbose:
             print(f'Study accession {study_accession_res} retrieved for {study_name}')
         study_accession = study_accession_res.get('study_attribute')
-        metadata = CellMetadata(metadata_path, study_file, study_file_id, study_accession=str(study_accession))
-        convention_res = get_connection().do_get(command=get_api_base() + 'metadata_schemas/alexandria_convention/latest/json',dry_run=dry_run)
-        if succeeded(convention_res ):
+        metadata = CellMetadata(
+            metadata_path,
+            study_file,
+            study_file_id,
+            study_accession=str(study_accession),
+        )
+        convention_res = get_connection().do_get(
+            command=get_api_base()
+            + 'metadata_schemas/alexandria_convention/latest/json',
+            dry_run=dry_run,
+        )
+        if succeeded(convention_res):
             if verbose:
                 print(f'Retreieved file for latest metdata convention')
             convention = convention_res["response"].json()
@@ -171,6 +192,7 @@ def validate_metadata_file(metadata_path):
             report_issues(metadata)
             exit_if_errors(metadata)
 
+
 def confirm(question):
     while True:
         answer = input(question + ' (y/n): ').lower().strip()
@@ -178,8 +200,8 @@ def confirm(question):
             return answer in ('y', 'yes')
 
 
-
-if __name__ == '__main__':
+def main():
+    global parsed_args
     parsed_args = create_parser().parse_args()
     if parsed_args.verbose:
         print("Args----")
@@ -251,7 +273,6 @@ if __name__ == '__main__':
         else:
             new_description = parsed_args.new_description
 
-
         ret = connection.edit_study_description(
             study_name=parsed_args.study_name,
             new_description=new_description,
@@ -267,8 +288,7 @@ if __name__ == '__main__':
         if verbose:
             print("STARTING GET EXTERNAL RESOURCES")
         ret = connection.get_study_external_resources(
-            study_name=parsed_args.study_name,
-            dry_run=parsed_args.dry_run,
+            study_name=parsed_args.study_name, dry_run=parsed_args.dry_run,
         )
         manage_call_return(ret, verbose)
         print('Study external resources: \n')
@@ -282,8 +302,7 @@ if __name__ == '__main__':
 
         # first get all external resource ids
         ret = connection.get_study_external_resources(
-            study_name=parsed_args.study_name,
-            dry_run=parsed_args.dry_run,
+            study_name=parsed_args.study_name, dry_run=parsed_args.dry_run,
         )
         manage_call_return(ret, verbose)
         ext_ids = [res['_id']['$oid'] for res in ret['external_resources']]
@@ -291,8 +310,10 @@ if __name__ == '__main__':
             print('No external resources associated with study.')
             exit()
         # confirm deletion with user
-        confirmed = confirm("Delete {} external resources associated ".format(len(ext_ids)) +
-                            "with study {}?".format(parsed_args.study_name))
+        confirmed = confirm(
+            "Delete {} external resources associated ".format(len(ext_ids))
+            + "with study {}?".format(parsed_args.study_name)
+        )
         if confirmed:
             if verbose:
                 print('Will continue deleting resources.')
@@ -427,3 +448,7 @@ if __name__ == '__main__':
 
     ## Validate and Upload bams
     ### TODO
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -9,13 +9,19 @@ https://singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1
 
 import requests
 import urllib3
-import Commandline
 import random
 import string
 import os
 import json
 
 import logging
+
+try:
+    # Used when importing internally and in tests
+    import Commandline
+except ImportError:
+    # Used when importing as external package
+    from . import Commandline
 
 # Constants
 c_AUTH = 'Authorization'
@@ -35,7 +41,9 @@ c_STUDY_DOES_NOT_EXIST_TEXT = "The study does not exist, please create first."
 c_INVALID_STUDY_NAME = 103
 c_INVALID_STUDY_NAME_TEXT = "Invalid study name. Use alphanumeric, spaces, dashes, '.', '/', '(', ')', '+', ',', ':'"
 c_INVALID_SHARE_MODE = 104
-c_INVALID_SHARE_MODE_TEXT = "The access you want to give the user is not an access I understand. Please check."
+c_INVALID_SHARE_MODE_TEXT = (
+    "The access you want to give the user is not an access I understand. Please check."
+)
 c_INVALID_SHARE_MISSING = 105
 c_INVALID_SHARE_MISSING_TEXT = "Can not remove the share, it does not exist."
 c_INVALID_STUDY_DESC = 106
@@ -73,8 +81,12 @@ c_PERMISSIONS = [c_ACCESS_EDIT, c_ACCESS_REVIEWER, c_ACCESS_VIEW, c_ACCESS_REMOV
 # SCP specific
 c_CLUSTER_FILE_TYPE = "Cluster"
 c_TEXT_TYPE = "text/plain"
-c_INVALID_STUDYDESC_CHAR = ["<",".","+","?",">"]
-c_VALID_STUDYNAME_CHAR = string.ascii_letters + string.digits + "".join([" ","-",".","/","(",")","+",",",":"])
+c_INVALID_STUDYDESC_CHAR = ["<", ".", "+", "?", ">"]
+c_VALID_STUDYNAME_CHAR = (
+    string.ascii_letters
+    + string.digits
+    + "".join([" ", "-", ".", "/", "(", ")", "+", ",", ":"])
+)
 
 # Matrix API specific
 c_MATRIX_API_OK = 200
@@ -89,11 +101,16 @@ class APIManager:
     '''
     Base class for REST API interaction. Handles common operations.
     '''
+
     def __init__(self):
         return
 
-    def login(self, token=None, dry_run=False,
-        api_base='https://singlecell.broadinstitute.org/single_cell/api/v1/'):
+    def login(
+        self,
+        token=None,
+        dry_run=False,
+        api_base='https://singlecell.broadinstitute.org/single_cell/api/v1/',
+    ):
         """
         Authenticates as user and get's token to perform actions on the user's behalf.
 
@@ -104,7 +121,8 @@ class APIManager:
         """
 
         ## TODO add in auth from a file.
-        if self.verbose: print("LOGIN")
+        if self.verbose:
+            print("LOGIN")
         if token is None:
             token = self.do_browser_login(dry_run=dry_run)
         self.token = token
@@ -120,13 +138,17 @@ class APIManager:
         :return: Authentication token
         '''
 
-        if self.verbose: print("BROWSER LOGIN")
+        if self.verbose:
+            print("BROWSER LOGIN")
         if dry_run:
-            if self.verbose: print("DRY_RUN:: Did not login")
-            return("DRY_RUN_TOKEN")
+            if self.verbose:
+                print("DRY_RUN:: Did not login")
+            return "DRY_RUN_TOKEN"
         cmdline.func_CMD(command="gcloud auth application-default login")
-        cmd_ret = cmdline.func_CMD(command="gcloud auth application-default print-access-token",stdout=True)
-        return(cmd_ret.decode("ASCII").strip(os.linesep))
+        cmd_ret = cmdline.func_CMD(
+            command="gcloud auth application-default print-access-token", stdout=True
+        )
+        return cmd_ret.decode("ASCII").strip(os.linesep)
 
     def do_get(self, command, dry_run=False):
         '''
@@ -142,12 +164,14 @@ class APIManager:
             print("DO GET")
             print(command)
         if dry_run:
-            return({c_SUCCESS_RET_KEY: True,c_CODE_RET_KEY: c_API_OK})
+            return {c_SUCCESS_RET_KEY: True, c_CODE_RET_KEY: c_API_OK}
         head = {'Accept': 'application/json'}
         if hasattr(self, 'token'):
             head[c_AUTH] = 'Bearer {}'.format(self.token)
 
-        return(self.check_api_return(requests.get(command, headers=head, verify=self.verify_https)))
+        return self.check_api_return(
+            requests.get(command, headers=head, verify=self.verify_https)
+        )
 
     def do_post(self, command, values, files=None, dry_run=False):
         '''
@@ -169,21 +193,26 @@ class APIManager:
             print(files)
         if dry_run:
             print("DRY_RUN:: Returning success.")
-            return({c_SUCCESS_RET_KEY: True,c_CODE_RET_KEY: c_API_OK})
-        head = {c_AUTH: 'token {}'.format(self.token),
-                'Accept': 'application/json'}
-        if self.verbose: print(head)
+            return {c_SUCCESS_RET_KEY: True, c_CODE_RET_KEY: c_API_OK}
+        head = {c_AUTH: 'token {}'.format(self.token), 'Accept': 'application/json'}
+        if self.verbose:
+            print(head)
         if files is None:
-            return(self.check_api_return(requests.post(command,
-                                                             headers=head,
-                                                             json=values,
-                                                             verify=self.verify_https)))
+            return self.check_api_return(
+                requests.post(
+                    command, headers=head, json=values, verify=self.verify_https
+                )
+            )
         else:
-            return(self.check_api_return(requests.post(command,
-                                                             headers=head,
-                                                             files=files,
-                                                             json=values,
-                                                             verify=self.verify_https)))
+            return self.check_api_return(
+                requests.post(
+                    command,
+                    headers=head,
+                    files=files,
+                    json=values,
+                    verify=self.verify_https,
+                )
+            )
 
     def do_patch(self, command, values, dry_run=False):
         '''
@@ -201,9 +230,11 @@ class APIManager:
             print(command)
             print(values)
         if dry_run:
-            return({c_SUCCESS_RET_KEY: True,c_CODE_RET_KEY: c_API_OK})
+            return {c_SUCCESS_RET_KEY: True, c_CODE_RET_KEY: c_API_OK}
         head = {c_AUTH: 'token {}'.format(self.token), 'Accept': 'application/json'}
-        return(self.check_api_return(requests.patch(command, headers=head, json=values, verify=self.verify_https)))
+        return self.check_api_return(
+            requests.patch(command, headers=head, json=values, verify=self.verify_https)
+        )
 
     def do_delete(self, command, dry_run=False):
         '''
@@ -219,9 +250,11 @@ class APIManager:
             print("DO DELETE")
             print(command)
         if dry_run:
-            return({c_SUCCESS_RET_KEY: True,c_CODE_RET_KEY: c_DELETE_OK})
+            return {c_SUCCESS_RET_KEY: True, c_CODE_RET_KEY: c_DELETE_OK}
         head = {c_AUTH: 'token {}'.format(self.token), 'Accept': 'application/json'}
-        return(self.check_api_return(requests.delete(command, headers=head, verify=self.verify_https)))
+        return self.check_api_return(
+            requests.delete(command, headers=head, verify=self.verify_https)
+        )
 
     def check_api_return(self, ret):
         '''
@@ -239,7 +272,9 @@ class APIManager:
             print(f'Error {ret.status_code}: {ret.reason}')
             if ret.status_code == 401:
                 print('')
-                print('Are you still signed in?  SCP automatically logs you out after a period of inactivity.')
+                print(
+                    'Are you still signed in?  SCP automatically logs you out after a period of inactivity.'
+                )
                 print('Try logging in and re-assigning your access token like so:')
                 print('')
                 print('\tgcloud auth login')
@@ -247,7 +282,7 @@ class APIManager:
                 print('')
         api_return[c_CODE_RET_KEY] = ret.status_code
         api_return[c_RESPONSE] = ret
-        return(api_return)
+        return api_return
 
     def get_boundary(self):
         '''
@@ -257,7 +292,7 @@ class APIManager:
         '''
 
         base = string.ascii_lowercase + string.digits
-        return("".join([random.choice(base) for i in range(c_BOUNDARY_LENGTH)]))
+        return "".join([random.choice(base) for i in range(c_BOUNDARY_LENGTH)])
 
 
 # The expected header
@@ -273,7 +308,7 @@ class SCPAPIManager(APIManager):
 
         APIManager.__init__(self)
         self.verbose = verbose
-        self.api_base = None # set in APIManager.login()
+        self.api_base = None  # set in APIManager.login()
         self.studies = None
         self.name_to_id = None
         self.bucket_id = None
@@ -303,25 +338,25 @@ class SCPAPIManager(APIManager):
         '''
 
         ret_status_codes = {
-            c_STUDY_EXISTS:c_STUDY_EXISTS_TEXT,
-            c_STUDY_DOES_NOT_EXIST:c_STUDY_DOES_NOT_EXIST_TEXT,
-            c_INVALID_STUDY_NAME:c_INVALID_STUDY_NAME_TEXT,
-            c_INVALID_SHARE_MODE:c_INVALID_SHARE_MODE_TEXT,
-            c_INVALID_SHARE_MISSING:c_INVALID_SHARE_MISSING_TEXT,
-            c_INVALID_STUDY_DESC:c_INVALID_STUDY_DESC_TEXT,
-            c_ATTRIBUTE_DOES_NOT_EXIST:c_ATTRIBUTE_DOES_NOT_EXIST_TEXT,
-            c_NO_ERROR:c_NO_ERROR_TEXT,
-            c_API_OK:c_NO_ERROR_TEXT,
-            c_DELETE_OK:c_NO_ERROR_TEXT,
-            c_API_AUTH:c_API_AUTH_TEXT,
-            c_API_SYNTAX_ERROR:c_API_SYNTAX_ERROR_TEXT,
-            c_API_AUTH_STUDY:c_API_AUTH_STUDY_TEXT,
-            c_API_UNKNOWN_STUDY:c_API_UNKNOWN_STUDY_TEXT,
-            c_API_CONTENT_HEADERS:c_API_CONTENT_HEADERS_TEXT,
-            c_API_INVALID_STUDY:c_API_INVALID_STUDY_TEXT,
-            c_API_BACKEND_ERROR:c_API_BACKEND_ERROR_TEXT
+            c_STUDY_EXISTS: c_STUDY_EXISTS_TEXT,
+            c_STUDY_DOES_NOT_EXIST: c_STUDY_DOES_NOT_EXIST_TEXT,
+            c_INVALID_STUDY_NAME: c_INVALID_STUDY_NAME_TEXT,
+            c_INVALID_SHARE_MODE: c_INVALID_SHARE_MODE_TEXT,
+            c_INVALID_SHARE_MISSING: c_INVALID_SHARE_MISSING_TEXT,
+            c_INVALID_STUDY_DESC: c_INVALID_STUDY_DESC_TEXT,
+            c_ATTRIBUTE_DOES_NOT_EXIST: c_ATTRIBUTE_DOES_NOT_EXIST_TEXT,
+            c_NO_ERROR: c_NO_ERROR_TEXT,
+            c_API_OK: c_NO_ERROR_TEXT,
+            c_DELETE_OK: c_NO_ERROR_TEXT,
+            c_API_AUTH: c_API_AUTH_TEXT,
+            c_API_SYNTAX_ERROR: c_API_SYNTAX_ERROR_TEXT,
+            c_API_AUTH_STUDY: c_API_AUTH_STUDY_TEXT,
+            c_API_UNKNOWN_STUDY: c_API_UNKNOWN_STUDY_TEXT,
+            c_API_CONTENT_HEADERS: c_API_CONTENT_HEADERS_TEXT,
+            c_API_INVALID_STUDY: c_API_INVALID_STUDY_TEXT,
+            c_API_BACKEND_ERROR: c_API_BACKEND_ERROR_TEXT,
         }
-        return(ret_status_codes.get(status_code, "That status code is not in use."))
+        return ret_status_codes.get(status_code, "That status code is not in use.")
 
     '''
     def check_species_genome(self, species, genome=None):
@@ -347,20 +382,24 @@ class SCPAPIManager(APIManager):
         :return: Response
         '''
 
-        if self.verbose: print("GET STUDIES")
+        if self.verbose:
+            print("GET STUDIES")
         resp = self.do_get(self.api_base + "studies", dry_run=dry_run)
         if dry_run:
             print("DRY_RUN:: Returned dummy names.")
             resp[c_STUDIES_RET_KEY] = ["DRY_RUN 1", "DRY_RUN 2"]
         else:
-            if(resp[c_SUCCESS_RET_KEY]):
+            if resp[c_SUCCESS_RET_KEY]:
                 studies_json = resp[c_RESPONSE].json()
                 self.study_objects = studies_json
                 self.studies = [str(element['name']) for element in studies_json]
-                self.name_to_id = [[str(element['name']), str(element['_id']['$oid'])] for element in studies_json]
-                self.name_to_id = {key: value for (key,value) in self.name_to_id}
+                self.name_to_id = [
+                    [str(element['name']), str(element['_id']['$oid'])]
+                    for element in studies_json
+                ]
+                self.name_to_id = {key: value for (key, value) in self.name_to_id}
                 resp[c_STUDIES_RET_KEY] = self.studies
-        return(resp)
+        return resp
 
     def is_valid_study_description(self, study_description):
         '''
@@ -373,7 +412,11 @@ class SCPAPIManager(APIManager):
         no_error = True
         for letter in study_description:
             if letter in c_INVALID_STUDYDESC_CHAR:
-                print("The following letter is not valid in a study description:'"+letter+"'")
+                print(
+                    "The following letter is not valid in a study description:'"
+                    + letter
+                    + "'"
+                )
                 no_error = False
         return no_error
 
@@ -388,16 +431,21 @@ class SCPAPIManager(APIManager):
         no_error = True
         for letter in study_name:
             if not letter in c_VALID_STUDYNAME_CHAR:
-                print("The following letter is not valid in a study name:'"+letter+"'")
+                print(
+                    "The following letter is not valid in a study name:'" + letter + "'"
+                )
                 no_error = False
         return no_error
 
-    def create_study(self, study_name,
-                     study_description='Single Cell Genomics Study',
-                     branding=None,
-                     billing=None,
-                     is_public=True,
-                     dry_run=False):
+    def create_study(
+        self,
+        study_name,
+        study_description='Single Cell Genomics Study',
+        branding=None,
+        billing=None,
+        is_public=True,
+        dry_run=False,
+    ):
         '''
         Create a study name using the REST API.
         Confirms the study does not exist before creating.
@@ -411,44 +459,38 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("CREATE STUDY:: " + study_name)
+        if self.verbose:
+            print("CREATE STUDY:: " + study_name)
         # Study variable validation
         ## Study must not exist
         if self.study_exists(study_name=study_name, dry_run=dry_run):
-            return ({
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_EXISTS
-            })
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_EXISTS}
         # Study name is restricted on letters
         if not self.is_valid_study_name(study_name):
-            return ({
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_INVALID_STUDY_NAME
-            })
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_INVALID_STUDY_NAME}
         # Study description should not have HTML
         if not self.is_valid_study_description(study_description):
-            return ({
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_INVALID_STUDY_DESC
-            })
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_INVALID_STUDY_DESC}
 
         # Make payload and do post
-        study_data = {"name": study_name,
-                     "description":study_description,
-                     "public":is_public}
+        study_data = {
+            "name": study_name,
+            "description": study_description,
+            "public": is_public,
+        }
         if not branding is None:
             study_data["firecloud_project"] = billing
         if not branding is None:
             study_data["branding_group_id"] = branding
-        resp = self.do_post(command=self.api_base + "studies", values=study_data, dry_run=dry_run)
+        resp = self.do_post(
+            command=self.api_base + "studies", values=study_data, dry_run=dry_run
+        )
         # Update study list
         if resp[c_SUCCESS_RET_KEY] and not dry_run:
             self.get_studies()
-        return(resp)
+        return resp
 
-    def get_study_attribute(self, study_name,
-                            attribute,
-                            dry_run=False):
+    def get_study_attribute(self, study_name, attribute, dry_run=False):
         '''
         Get a study attribute using the REST API.
 
@@ -457,18 +499,20 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("LOOKING AT " + study_name)
+        if self.verbose:
+            print("LOOKING AT " + study_name)
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         study_id = self.study_name_to_id(study_name, dry_run=dry_run)
 
-        ret_study = self.do_get(command=self.api_base + "studies/"+str(study_id),
-                                dry_run=dry_run)
+        ret_study = self.do_get(
+            command=self.api_base + "studies/" + str(study_id), dry_run=dry_run
+        )
         if dry_run:
             print("DRY_RUN:: Returned dummy attribute.")
             ret_study[c_ATTR_RET_KEY] = "DUMMY ATTRIBUTE"
@@ -479,16 +523,15 @@ class SCPAPIManager(APIManager):
                 print('The requested study attribute is not available.')
                 return {
                     c_SUCCESS_RET_KEY: False,
-                    c_CODE_RET_KEY: c_ATTRIBUTE_DOES_NOT_EXIST
+                    c_CODE_RET_KEY: c_ATTRIBUTE_DOES_NOT_EXIST,
                 }
             ret_study[c_ATTR_RET_KEY] = study[attribute]
 
-        return(ret_study)
+        return ret_study
 
-    def edit_study_description(self, study_name,
-                               new_description,
-                               accept_html=False,
-                               dry_run=False):
+    def edit_study_description(
+        self, study_name, new_description, accept_html=False, dry_run=False
+    ):
         '''
         Edit a study description using the REST API.
         Confirms the study exists.
@@ -499,35 +542,33 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("EDITING DESCRIPTION FOR " + study_name)
+        if self.verbose:
+            print("EDITING DESCRIPTION FOR " + study_name)
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         study_id = self.study_name_to_id(study_name, dry_run=dry_run)
 
         # New study description should not have HTML
         # except when it needs to...
         if not accept_html and not self.is_valid_study_description(new_description):
-            return ({
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_INVALID_STUDY_DESC
-            })
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_INVALID_STUDY_DESC}
 
-        description_info = {"study_id": study_id,
-                            "description": new_description}
+        description_info = {"study_id": study_id, "description": new_description}
 
-        update_ret = self.do_patch(command=self.api_base +"studies/"+str(study_id),
-                                   values=description_info,
-                                   dry_run=dry_run)
+        update_ret = self.do_patch(
+            command=self.api_base + "studies/" + str(study_id),
+            values=description_info,
+            dry_run=dry_run,
+        )
 
-        return(update_ret)
+        return update_ret
 
-    def get_study_external_resources(self, study_name,
-                                     dry_run=False):
+    def get_study_external_resources(self, study_name, dry_run=False):
         '''
         Get a study's external resources using the REST API.
 
@@ -535,32 +576,34 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("LOOKING AT " + study_name)
+        if self.verbose:
+            print("LOOKING AT " + study_name)
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         study_id = self.study_name_to_id(study_name, dry_run=dry_run)
 
-        study_resources = self.do_get(command=self.api_base + "studies/"+str(study_id) +
-                                "/external_resources",
-                                dry_run=dry_run)
+        study_resources = self.do_get(
+            command=self.api_base + "studies/" + str(study_id) + "/external_resources",
+            dry_run=dry_run,
+        )
         if dry_run:
             print("DRY_RUN:: Returned dummy external resources.")
-            study_resources[c_EXT_RET_KEY] = [{'_id': 'EXT_REC_DUMMY_1'},
-                                              {'_id': 'EXT_REC_DUMMY_2'}]
+            study_resources[c_EXT_RET_KEY] = [
+                {'_id': 'EXT_REC_DUMMY_1'},
+                {'_id': 'EXT_REC_DUMMY_2'},
+            ]
         else:
             resources = study_resources[c_RESPONSE].json()
             study_resources[c_EXT_RET_KEY] = resources
 
-        return(study_resources)
+        return study_resources
 
-    def delete_study_external_resource(self, study_name,
-                                       resource_id,
-                                       dry_run=False):
+    def delete_study_external_resource(self, study_name, resource_id, dry_run=False):
         '''
         Delete a study's external resource using the REST API.
 
@@ -569,25 +612,30 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("LOOKING AT " + study_name)
+        if self.verbose:
+            print("LOOKING AT " + study_name)
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         study_id = self.study_name_to_id(study_name, dry_run=dry_run)
-        ret_delete = self.do_delete(command=self.api_base + "studies/"+str(study_id) +
-                                    "/external_resources/" + resource_id,
-                                    dry_run=dry_run)
+        ret_delete = self.do_delete(
+            command=self.api_base
+            + "studies/"
+            + str(study_id)
+            + "/external_resources/"
+            + resource_id,
+            dry_run=dry_run,
+        )
 
-        return(ret_delete)
+        return ret_delete
 
-    def create_study_external_resource(self, study_name,
-                                       title, url, description,
-                                       publication_url = False,
-                                       dry_run=False):
+    def create_study_external_resource(
+        self, study_name, title, url, description, publication_url=False, dry_run=False
+    ):
         '''
         Create an external resource for a study using the REST API.
 
@@ -599,31 +647,38 @@ class SCPAPIManager(APIManager):
         :param dry_run: If true, will do a dry run with no actual execution of functionality.
         :return: Response
         '''
-        if self.verbose: print("CREATING RESOURCE FOR " + study_name)
+        if self.verbose:
+            print("CREATING RESOURCE FOR " + study_name)
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         study_id = self.study_name_to_id(study_name, dry_run=dry_run)
 
-        #TODO: check whether resource already exists in some form
-        #TODO: checks for formats of URL, description, etc
+        # TODO: check whether resource already exists in some form
+        # TODO: checks for formats of URL, description, etc
         # Make payload and do post
-        resource_data = {"title": title,
-                         "url":url,
-                         "description":description,
-                         "publication_url":publication_url}
+        resource_data = {
+            "title": title,
+            "url": url,
+            "description": description,
+            "publication_url": publication_url,
+        }
 
-        resp = self.do_post(command=self.api_base + "studies/"+str(study_id) + "/external_resources",
-                            values=resource_data,
-                            dry_run=dry_run)
+        resp = self.do_post(
+            command=self.api_base + "studies/" + str(study_id) + "/external_resources",
+            values=resource_data,
+            dry_run=dry_run,
+        )
 
-        return(resp)
+        return resp
 
-    def set_permission(self, study_name, email, access, deliver_email=False, dry_run=False):
+    def set_permission(
+        self, study_name, email, access, deliver_email=False, dry_run=False
+    ):
         '''
         Sets permission on a study.
 
@@ -638,54 +693,71 @@ class SCPAPIManager(APIManager):
             print("SET PERMISSION: ".join(str(i) for i in [study_name, email, access]))
         # Make sure the access value is valid
         if not access in c_PERMISSIONS:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_INVALID_SHARE_MODE
-            }
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_INVALID_SHARE_MODE}
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
         studyId = self.study_name_to_id(study_name, dry_run=dry_run)
 
         # Get the share id for the email
-        ret_shares = self.do_get(command=self.api + "studies/"+str(studyId)+"/study_shares",
-                                 dry_run=dry_run)
+        ret_shares = self.do_get(
+            command=self.api + "studies/" + str(studyId) + "/study_shares",
+            dry_run=dry_run,
+        )
         share_id = None
         for share in ret_shares[c_RESPONSE].json():
-            if share["email"]==email:
+            if share["email"] == email:
                 share_id = share['_id']['$oid']
 
-        permissions_info = {"study_id": studyId,
-                            "study_share":{"email":email,
-                                           "permission":access,
-                                           "deliver_emails":deliver_email}}
+        permissions_info = {
+            "study_id": studyId,
+            "study_share": {
+                "email": email,
+                "permission": access,
+                "deliver_emails": deliver_email,
+            },
+        }
         if share_id is None:
             # Delete share
-            if(access==c_ACCESS_REMOVE):
+            if access == c_ACCESS_REMOVE:
                 return {
                     c_SUCCESS_RET_KEY: False,
-                    c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
+                    c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST,
                 }
             # Set shares for study given it does not exist
-            ret = self.do_post(command=self.api+"studies/"+str(studyId)+"/study_shares",
-                               values=permissions_info,
-                               dry_run=dry_run)
-            return(ret)
+            ret = self.do_post(
+                command=self.api + "studies/" + str(studyId) + "/study_shares",
+                values=permissions_info,
+                dry_run=dry_run,
+            )
+            return ret
         else:
             # Delete share
-            if(access==c_ACCESS_REMOVE):
-                ret_delete = self.do_delete(command=self.api+"studies/"+str(studyId)+"/study_shares/"+share_id,
-                                            dry_run=dry_run)
-                return(ret_delete)
+            if access == c_ACCESS_REMOVE:
+                ret_delete = self.do_delete(
+                    command=self.api
+                    + "studies/"
+                    + str(studyId)
+                    + "/study_shares/"
+                    + share_id,
+                    dry_run=dry_run,
+                )
+                return ret_delete
             # Update shares for a study that has the shares
-            update_ret = self.do_patch(command=self.api+"studies/"+str(studyId)+"/study_shares/"+share_id,
-                                       values=permissions_info,
-                                       dry_run=dry_run)
-            return(update_ret)
+            update_ret = self.do_patch(
+                command=self.api
+                + "studies/"
+                + str(studyId)
+                + "/study_shares/"
+                + share_id,
+                values=permissions_info,
+                dry_run=dry_run,
+            )
+            return update_ret
 
     def study_exists(self, study_name, dry_run=False):
         '''
@@ -703,8 +775,8 @@ class SCPAPIManager(APIManager):
                 return False
                 #### TODO throw exception
         if dry_run:
-            return(True)
-        return(study_name in self.studies)
+            return True
+        return study_name in self.studies
 
     def study_name_to_id(self, name, dry_run=False):
         '''
@@ -718,9 +790,9 @@ class SCPAPIManager(APIManager):
             print("STUDY NAME TO ID")
         if dry_run:
             print("DRY_RUN:: returning a dummy id")
-            return("1")
+            return "1"
         else:
-            return(self.name_to_id.get(name, None))
+            return self.name_to_id.get(name, None)
 
     @staticmethod
     def upload_via_gsutil(bucket_id, file_path):
@@ -747,19 +819,28 @@ class SCPAPIManager(APIManager):
 
         return [gsutil_stat, filename]
 
-    def upload_study_file(self, file, file_type, study_name, name=None,
-                    description="", parse=False, dry_run=False, **kwargs):
+    def upload_study_file(
+        self,
+        file,
+        file_type,
+        study_name,
+        name=None,
+        description="",
+        parse=False,
+        dry_run=False,
+        **kwargs,
+    ):
         """Wrapper for study file upload.
 
         Upload via gsutil, then point SCP to resulting object in bucket.
         """
 
         # Error if the study does not exist
-        if not self.study_exists(study_name=study_name, dry_run=dry_run) and not dry_run:
-            return {
-                c_SUCCESS_RET_KEY: False,
-                c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST
-            }
+        if (
+            not self.study_exists(study_name=study_name, dry_run=dry_run)
+            and not dry_run
+        ):
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_STUDY_DOES_NOT_EXIST}
         # Convert study name to study id
 
         # python manage_study.py --env development --token=`gcloud auth print-access-token` upload-cluster --file ../demo_data/cluster_example.txt --study apitest --cluster-name test-cluster --species "Felis catus" --genome "Felis_catus_9.0"
@@ -781,7 +862,7 @@ class SCPAPIManager(APIManager):
                 'upload_file_name': filename,
                 'upload_content_type': gsutil_stat['Content-Type'],
                 'upload_file_size': int(gsutil_stat['Content-Length']),
-                'generation': gsutil_stat['Generation']
+                'generation': gsutil_stat['Generation'],
             }
         }
         for kwarg in kwargs:
@@ -789,39 +870,81 @@ class SCPAPIManager(APIManager):
             # for expression matrix files
             file_fields['study_file'][kwarg] = kwargs[kwarg]
 
-        ret = self.do_post(command=self.api_base + 'studies/' + study_id + '/study_files',
-                           values=file_fields, dry_run=dry_run)
+        ret = self.do_post(
+            command=self.api_base + 'studies/' + study_id + '/study_files',
+            values=file_fields,
+            dry_run=dry_run,
+        )
         # print(f'/study_files response: {ret["response"].text}')
 
         if parse:
             study_files_response = ret['response'].json()
             study_file_id = study_files_response['_id']['$oid']
-            parse = f'{self.api_base}studies/{study_id}/study_files/{study_file_id}/parse'
+            parse = (
+                f'{self.api_base}studies/{study_id}/study_files/{study_file_id}/parse'
+            )
             ret = self.do_post(command=parse, values=None, dry_run=dry_run)
             # print(f'/parse response: {ret["response"].text}')
 
-        return(ret)
+        return ret
 
-    def upload_metadata(self, file, study_name, description="",
-                        use_convention=False, dry_run=False):
-        if self.verbose: print("UPLOAD METADATA FILE")
-        return self.upload_study_file(file, 'Metadata', study_name,
-            description=description, parse=True, use_metadata_convention=use_convention,
-            dry_run=dry_run)
+    def upload_metadata(
+        self, file, study_name, description="", use_convention=False, dry_run=False
+    ):
+        if self.verbose:
+            print("UPLOAD METADATA FILE")
+        return self.upload_study_file(
+            file,
+            'Metadata',
+            study_name,
+            description=description,
+            parse=True,
+            use_metadata_convention=use_convention,
+            dry_run=dry_run,
+        )
 
-    def upload_expression_matrix(self, file, study_name, species=None,
-                            genome=None, description="", dry_run=False):
-        if self.verbose: print("UPLOAD EXPRESSION MATRIX FILE")
-        return self.upload_study_file(file, 'Expression Matrix', study_name,
-                                description=description, species=species,
-                                genome=genome, parse=True, dry_run=dry_run)
+    def upload_expression_matrix(
+        self, file, study_name, species=None, genome=None, description="", dry_run=False
+    ):
+        if self.verbose:
+            print("UPLOAD EXPRESSION MATRIX FILE")
+        return self.upload_study_file(
+            file,
+            'Expression Matrix',
+            study_name,
+            description=description,
+            species=species,
+            genome=genome,
+            parse=True,
+            dry_run=dry_run,
+        )
 
-    def upload_cluster(self, file, study_name, cluster_name, description="",
-                    x="X", y="Y", z="Z", dry_run=False):
-        if self.verbose: print("UPLOAD CLUSTER FILE")
-        return self.upload_study_file(file, 'Cluster', study_name,
-            cluster_name=cluster_name, description=description,
-            x=x, y=x, z=x, parse=True, dry_run=dry_run)
+    def upload_cluster(
+        self,
+        file,
+        study_name,
+        cluster_name,
+        description="",
+        x="X",
+        y="Y",
+        z="Z",
+        dry_run=False,
+    ):
+        if self.verbose:
+            print("UPLOAD CLUSTER FILE")
+        return self.upload_study_file(
+            file,
+            'Cluster',
+            study_name,
+            cluster_name=cluster_name,
+            description=description,
+            x=x,
+            y=x,
+            z=x,
+            parse=True,
+            dry_run=dry_run,
+        )
+
 
 class DSSAPIManager(APIManager):
     '''
@@ -834,7 +957,8 @@ class DSSAPIManager(APIManager):
         '''
 
         APIManager.__init__(self)
-        if self.verbose: print("INIT")
+        if self.verbose:
+            print("INIT")
         self.api = "https://dss.data.humancellatlas.org/v1/"
 
 
@@ -862,12 +986,12 @@ class MatrixAPIManager(APIManager):
         '''
 
         ret_status_codes = {
-            c_MATRIX_API_OK:c_NO_ERROR_TEXT,
-            c_MATRIX_REQUEST_API_OK:c_NO_ERROR_TEXT,
-            c_MATRIX_BAD_FORMAT:c_MATRIX_BAD_FORMAT_TEXT,
-            c_API_SYNTAX_ERROR:c_API_SYNTAX_ERROR_TEXT
+            c_MATRIX_API_OK: c_NO_ERROR_TEXT,
+            c_MATRIX_REQUEST_API_OK: c_NO_ERROR_TEXT,
+            c_MATRIX_BAD_FORMAT: c_MATRIX_BAD_FORMAT_TEXT,
+            c_API_SYNTAX_ERROR: c_API_SYNTAX_ERROR_TEXT,
         }
-        return(ret_status_codes.get(status_code, "That status code is not in use."))
+        return ret_status_codes.get(status_code, "That status code is not in use.")
 
     def get_supported_types(self, dry_run=False):
         '''
@@ -878,13 +1002,13 @@ class MatrixAPIManager(APIManager):
         '''
         print("GET SUPPORTED TYPES")
         if dry_run:
-            self.supportedTypes = ["test_type","test_type"]
+            self.supportedTypes = ["test_type", "test_type"]
             return {c_SUCCESS_RET_KEY: True}
         if self.supportedTypes is None:
-            resp =self.do_get(self.api + "formats")
+            resp = self.do_get(self.api + "formats")
             if resp[c_SUCCESS_RET_KEY]:
                 self.supportedTypes = resp[c_RESPONSE].json()
-        return(resp)
+        return resp
 
     def request_matrix(self, ids, format="zarr", dry_run=False):
         '''
@@ -898,10 +1022,8 @@ class MatrixAPIManager(APIManager):
         '''
         print("REQUEST MATRIX BY IDs")
         if not format in self.get_supported_types():
-            return {c_SUCCESS_RET_KEY: False,
-                    c_CODE_RET_KEY: c_MATRIX_BAD_FORMAT}
-        bundleInfo = {"bundle_fqids":ids,"format":format}
-        resp = self.do_post(self.api,
-                            values=bundleInfo,
-                            dry_run=dry_run)
-        return(resp)
+            return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_MATRIX_BAD_FORMAT}
+        bundleInfo = {"bundle_fqids": ids, "format": format}
+        resp = self.do_post(self.api, values=bundleInfo, dry_run=dry_run)
+        return resp
+

--- a/scripts/tests/test_manage_study.py
+++ b/scripts/tests/test_manage_study.py
@@ -57,11 +57,10 @@ class ManageStudyTestCase(unittest.TestCase):
     def set_up_manage_study(self, *args):
         return create_parser().parse_args(args)
 
-    @patch('manage_study.get_connection', side_effect=mock_get_connection)
     @patch('manage_study.succeeded', return_value=True)
     @patch('manage_study.get_api_base', side_effect=mock_get_api_base)
     def test_validate_metadata_file_invalid_ontology(
-        self, mock_get_connection, mock_succeeded, mock_get_api_base,
+        self, mock_succeeded, mock_get_api_base,
     ):
         """Unconventional metadata file should fail validation
 
@@ -82,14 +81,13 @@ class ManageStudyTestCase(unittest.TestCase):
 
         invalid_metadata_path = 'tests/data/invalid_array_v1.1.3.tsv'
         with self.assertRaises(SystemExit) as cm:
-            validate_metadata_file(parsed_args)
+            validate_metadata_file(parsed_args, mock_get_connection())
         self.assertEqual(cm.exception.code, 1)
 
-    @patch('manage_study.get_connection', side_effect=mock_get_connection)
     @patch('manage_study.succeeded', return_value=True)
     @patch('manage_study.get_api_base', side_effect=mock_get_api_base)
     def test_validate_metadata_file_valid_ontology(
-        self, mock_get_connection, mock_succeeded, mock_get_api_base,
+        self, mock_succeeded, mock_get_api_base,
     ):
         """Conventional metadata file should pass validation
 
@@ -107,7 +105,9 @@ class ManageStudyTestCase(unittest.TestCase):
         SCPAPIManager = Mock()
         SCPAPIManager.get_study_attribute.return_value = 'SCP555'
         valid_metadata_path = 'tests/data/valid_array_v20.0.0.tsv'
-        not self.assertRaises(SystemExit, validate_metadata_file(parsed_args))
+        not self.assertRaises(
+            SystemExit, validate_metadata_file(parsed_args, mock_get_connection())
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_manage_study.py
+++ b/scripts/tests/test_manage_study.py
@@ -11,6 +11,7 @@ from ingest.validation.validate_metadata import (
     exit_if_errors,
     validate_input_metadata,
 )
+
 sys.path.append('.')
 
 from manage_study import validate_metadata_file
@@ -30,87 +31,84 @@ def mocked_requests_get(*args, **kwargs):
             return self.json_data
 
     url = args[0]
-    convention_file_path= 'tests/data/alexandria_convention_schema_2.1.0.json'
+    convention_file_path = 'tests/data/alexandria_convention_schema_2.1.0.json'
     if url == 'metadata_schemas/alexandria_convention/latest/json':
         with open(convention_file_path) as f:
             return MockResponse(json.load(f), 200, reason='OK')
     return MockResponse(None, 404)
 
+
 def mock_get_connection(*args, **kwargs):
     class MockResponse:
-        def get_study_attribute(study_name,attribute, dry_run):
+        def get_study_attribute(study_name, attribute, dry_run):
             return {'success': True, 'study_attribute': 'SCP599'}
 
-        def do_get(command=None,dry_run=None):
-            return {'response':mocked_requests_get(command)}
+        def do_get(command=None, dry_run=None):
+            return {'response': mocked_requests_get(command)}
 
     return MockResponse
 
-def mock_get_parsed_args():
-    return Mock()
 
-def mock_get_api_base():
+def mock_get_api_base(parsed_args):
     return ''
 
+
 class ManageStudyTestCase(unittest.TestCase):
-    def set_up_manage_study(self,*args):
+    def set_up_manage_study(self, *args):
         return create_parser().parse_args(args)
 
     @patch('manage_study.get_connection', side_effect=mock_get_connection)
     @patch('manage_study.succeeded', return_value=True)
-    @patch('manage_study.get_parsed_args')
-    @patch('manage_study.get_api_base', side_effect = mock_get_api_base)
-    def test_validate_metadata_file_invalid_ontology(self,
-        mock_get_connection,
-        mock_succeeded,
-        mock_get_parsed_args,
-        mock_get_api_base):
+    @patch('manage_study.get_api_base', side_effect=mock_get_api_base)
+    def test_validate_metadata_file_invalid_ontology(
+        self, mock_get_connection, mock_succeeded, mock_get_api_base,
+    ):
         """Unconventional metadata file should fail validation
 
         This basic test ensures that the external dependency
         `scp-ingest-pipeline` in our public CLI works as expected.
         """
-        mock_get_parsed_args.return_value = self.set_up_manage_study(
-        'upload-metadata',
-        '--study-name',
-        'CLI test',
-        '--file',
-        'tests/data/invalid_array_v1.1.3.tsv',
-        '--use-convention'
+        parsed_args = self.set_up_manage_study(
+            'upload-metadata',
+            '--study-name',
+            'CLI test',
+            '--file',
+            'tests/data/invalid_array_v1.1.3.tsv',
+            '--use-convention',
         )
-        SCPAPIManager= Mock()
-        SCPAPIManager.get_study_attribute.return_value= 'SCP555'
+        print(parsed_args)
+        SCPAPIManager = Mock()
+        SCPAPIManager.get_study_attribute.return_value = 'SCP555'
 
         invalid_metadata_path = 'tests/data/invalid_array_v1.1.3.tsv'
         with self.assertRaises(SystemExit) as cm:
-            validate_metadata_file(invalid_metadata_path)
+            validate_metadata_file(parsed_args)
         self.assertEqual(cm.exception.code, 1)
 
     @patch('manage_study.get_connection', side_effect=mock_get_connection)
     @patch('manage_study.succeeded', return_value=True)
-    @patch('manage_study.get_parsed_args')
-    @patch('manage_study.get_api_base', side_effect = mock_get_api_base)
-    def test_validate_metadata_file_valid_ontology(self,
-        mock_get_connection,
-        mock_succeeded,
-        mock_get_parsed_args,
-        mock_get_api_base):
+    @patch('manage_study.get_api_base', side_effect=mock_get_api_base)
+    def test_validate_metadata_file_valid_ontology(
+        self, mock_get_connection, mock_succeeded, mock_get_api_base,
+    ):
         """Conventional metadata file should pass validation
 
         This basic test ensures that the external dependency
         `scp-ingest-pipeline` in our public CLI works as expected.
         """
-        mock_get_parsed_args.return_value = self.set_up_manage_study(
-        'upload-metadata',
-        '--study-name',
-        'CLI test',
-        '--file',
-        'tests/data/valid_array_v20.0.0.tsv',
-        '--use-convention'
+        parsed_args = self.set_up_manage_study(
+            'upload-metadata',
+            '--study-name',
+            'CLI test',
+            '--file',
+            'tests/data/valid_array_v20.0.0.tsv',
+            '--use-convention',
         )
-        SCPAPIManager= Mock()
-        SCPAPIManager.get_study_attribute.return_value= 'SCP555'
+        SCPAPIManager = Mock()
+        SCPAPIManager.get_study_attribute.return_value = 'SCP555'
         valid_metadata_path = 'tests/data/valid_array_v20.0.0.tsv'
-        not self.assertRaises(SystemExit, validate_metadata_file(valid_metadata_path))
+        not self.assertRaises(SystemExit, validate_metadata_file(parsed_args))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/broadinstitute/single_cell_portal',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline',],
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline>=1.3.7',],
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/broadinstitute/single_cell_portal',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline=1.3.9',],
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.3.9',],
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+with open('README.md', 'r') as fh:
+    long_description = fh.read()
+
+setup(
+    name='single_cell_portal',
+    version='0.1rc1',
+    description='Convenience scripts for Single Cell Portal',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/broadinstitute/single_cell_portal',
+    author='Single Cell Portal team',
+    author_email='scp-support@broadinstitute.zendesk.com',
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline',],
+    packages=find_packages(),
+    entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: BSD License',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Programming Language :: Python :: 3.7',
+    ],
+    python_requires='>=3.7',
+)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setup(
-    name='single_cell_portal',
+    name='single-cell-portal',
     version='0.1rc1',
     description='Convenience scripts for Single Cell Portal',
     long_description=long_description,
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='single-cell-portal',
-    version='0.1rc1',
+    version='0.1',
     description='Convenience scripts for Single Cell Portal',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/broadinstitute/single_cell_portal',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline>=1.3.7',],
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline=1.3.9',],
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[


### PR DESCRIPTION
Update manage_study.py to run as an executable (manage-study) after installation of the single_cell_portal package from PyPI.
Minor updates to repo (setup.py, __init__.py etc) for publishing to PyPI.

Currently single_cell_portal is published to TestPyPI, to install:
`pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple  single_cell_portal`

### Expected current behavior:

single_cell_portal installs scp-ingest-pipeline - the available version is 1.3.7 which will fail on .txt files with "_csv.Error: Could not determine delimiter"

Running manage-study against the staging server with a valid .txt metadata file against the metadata convention will fail (due to local 1.3.7 code) even though the staging server is running ingest 1.3.9

### To test:
(First, rename a synthetic metadata file from .tsv to .txt)

```
gcloud config configurations activate default

ACCESS_TOKEN=`gcloud auth print-access-token`

STUDY_NAME=<name of a staging study w/o a current metadata file>

manage-study --environment staging --token=$ACCESS_TOKEN  upload-metadata --file metadata.txt --study-name $STUDY_NAME --use-convention
```
running with the same file saved as metadata.tsv should succeed

These changes support SCP-2414.