### PR TITLE
update README to contact SCP support via Zendesk (SCP-2643)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To report a bug or suggest an improvement please create a new issue at: https://
 
 ## Need Help?
 
-Email us at single_cell_portal@broadinstitute.org
+Email us at scp-support@broadinstitute.zendesk.com
 
 Happy Science!!!
 


### PR DESCRIPTION
Updating README to contact SCP support using "scp-support@broadinstitute.zendesk.com", consolidating all SCP support issues to use Zendesk.

This supports SCP-2643 for our public facing Github repo - there will be a parallel PR in `single_cell_portal_core`