### PR TITLE
update manage-study to handle full_description (SCP-2661)

### DIFF
--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -474,9 +474,13 @@ class SCPAPIManager(APIManager):
 
         # Make payload and do post
         study_data = {
-            "name": study_name,
-            "description": study_description,
-            "public": is_public,
+            "study": {
+                "name": study_name,
+                "study_detail_attributes": {
+                    "full_description": study_description
+                },
+                "public": is_public
+            }
         }
         if not branding is None:
             study_data["firecloud_project"] = billing
@@ -558,7 +562,15 @@ class SCPAPIManager(APIManager):
         if not accept_html and not self.is_valid_study_description(new_description):
             return {c_SUCCESS_RET_KEY: False, c_CODE_RET_KEY: c_INVALID_STUDY_DESC}
 
-        description_info = {"study_id": study_id, "description": new_description}
+        description_info = {
+            "study": {
+                "study_id": study_id,
+                "name": study_name,
+                "study_detail_attributes": {
+                    "full_description": new_description
+                }
+            }
+        }
 
         update_ret = self.do_patch(
             command=self.api_base + "studies/" + str(study_id),

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -565,7 +565,6 @@ class SCPAPIManager(APIManager):
         description_info = {
             "study": {
                 "study_id": study_id,
-                "name": study_name,
                 "study_detail_attributes": {
                     "full_description": new_description
                 }

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='single-cell-portal',
-    version='0.1.1',
+    version='0.1.2',
     description='Convenience scripts for Single Cell Portal',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/broadinstitute/single_cell_portal',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.3.10',],
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.5.4,],
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[


### PR DESCRIPTION
Studies where full_description is Null will fail to load in the Portal. This PR updates scp_api.py so description text is passed as full_description under study_detail_attributes. Also increments version for push to PyPI.

This satisfies SCP-2661.

Testing for regression of this issue will require manual testing (study creation did not break, only trying to load the created study).