### PR TITLE
increment requirements.txt in parallel with PyPI release (SCP-2661)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=0.16.2
 requests>=2.21.0
-scp-ingest-pipeline==1.3.10
+scp-ingest-pipeline==1.5.4
 
 # For faster development iterations.
 # ../../scp-ingest-pipeline

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/broadinstitute/single_cell_portal',
     author='Single Cell Portal team',
     author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.5.4,],
+    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.5.4'],
     packages=find_packages(),
     entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
     classifiers=[


### PR DESCRIPTION
Neglected to pin requirements.txt to latest ingest pipeline version for PyPI release.

This PR facilitates a PyPI release to support SCP-2661.