### PR TITLE
Supply user-agent string with manage-study API requests (SCP-2415)

### DIFF
--- a/scripts/cli_parser.py
+++ b/scripts/cli_parser.py
@@ -41,10 +41,10 @@ def create_parser():
         help="Do not check file locally before uploading.",
     )
     args.add_argument(
-        "--no-version-check",
-        dest="check_version",
+        "--no-user-agent",
+        dest="user_agent",
         action="store_false",
-        help="Do not check for ingest pipeline version.",
+        help="Do not send user-agent string for ingest pipeline version.",
     )
     args.add_argument(
         "--verbose", action="store_true", help="Whether to print debugging information"

--- a/scripts/cli_parser.py
+++ b/scripts/cli_parser.py
@@ -13,202 +13,216 @@ c_TOOL_PERMISSION = "permission"
 c_TOOL_STUDY = "create-study"
 c_TOOL_STUDY_EDIT_DESC = "edit-study-description"
 c_TOOL_STUDY_GET_ATTR = "get-study-attribute"
-c_TOOL_STUDY_GET_EXT = 'get-study-external-resources'
-c_TOOL_STUDY_DEL_EXT = 'delete-study-external-resources'
-c_TOOL_STUDY_CREATE_EXT = 'create-study-external-resource'
+c_TOOL_STUDY_GET_EXT = "get-study-external-resources"
+c_TOOL_STUDY_DEL_EXT = "delete-study-external-resources"
+c_TOOL_STUDY_CREATE_EXT = "create-study-external-resource"
 
 
 def create_parser():
     args = argparse.ArgumentParser(
-        prog='manage-study',
+        prog="manage-study",
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     args.add_argument(
-        '--token',
+        "--token",
         default=None,
-        help='Personal token after logging into Google (OAuth2).  This token is not persisted after the finish of the script.',
+        help="Personal token after logging into Google (OAuth2).  This token is not persisted after the finish of the script.",
     )
     args.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Walk through and log what would occur, without performing the actions.',
+        "--dry-run",
+        action="store_true",
+        help="Walk through and log what would occur, without performing the actions.",
     )
     args.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        help='Do not check file locally before uploading.',
+        "--no-validate",
+        dest="validate",
+        action="store_false",
+        help="Do not check file locally before uploading.",
     )
     args.add_argument(
-        '--verbose', action='store_true', help='Whether to print debugging information'
+        "--no-version-check",
+        dest="check_version",
+        action="store_false",
+        help="Do not check for ingest pipeline version.",
+    )
+    args.add_argument(
+        "--verbose", action="store_true", help="Whether to print debugging information"
     )
 
     args.add_argument(
-        '--environment',
-        default='production',
-        choices=['development', 'staging', 'production'],
-        help='API environment to use',
+        "--environment",
+        default="production",
+        choices=["development", "staging", "production"],
+        help="API environment to use",
     )
 
     # Create tools (subparser)
-    subargs = args.add_subparsers(dest='command')
+    subargs = args.add_subparsers(dest="command")
 
     ## List studies subparser
     parser_list_studies = subargs.add_parser(
         c_TOOL_LIST_STUDY,
-        help="List studies. \""
+        help='List studies. "'
         + args.prog
         + " "
         + c_TOOL_LIST_STUDY
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_list_studies.add_argument(
-        '--summary',
-        dest='summarize_list',
-        action='store_true',
-        help='Do not list, only summarize number of accessible studies',
+        "--summary",
+        dest="summarize_list",
+        action="store_true",
+        help="Do not list, only summarize number of accessible studies",
     )
 
     ## Create study subparser
     parser_create_studies = subargs.add_parser(
         c_TOOL_STUDY,
-        help="Create a study. \""
+        help='Create a study. "'
         + args.prog
         + " "
         + c_TOOL_STUDY
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_create_studies.add_argument(
-        '--description',
-        dest='study_description',
+        "--description",
+        dest="study_description",
         default="Single Cell Genomics Study",
-        help='Short description of the study',
+        help="Short description of the study",
     )
     parser_create_studies.add_argument(
-        '--study-name', required=True, help='Short name of the study'
+        "--study-name", required=True, help="Short name of the study"
     )
     parser_create_studies.add_argument(
-        '--branding', default=None, help='Portal branding to associate with the study',
-    )
-    parser_create_studies.add_argument(
-        '--billing',
+        "--branding",
         default=None,
-        help='Portal billing project to associate with the study',
+        help="Portal branding to associate with the study",
     )
     parser_create_studies.add_argument(
-        '--is-private', action='store_true', help='Whether the study is private'
+        "--billing",
+        default=None,
+        help="Portal billing project to associate with the study",
+    )
+    parser_create_studies.add_argument(
+        "--is-private", action="store_true", help="Whether the study is private"
     )
 
     # Create edit description subparser
     parser_edit_description = subargs.add_parser(
         c_TOOL_STUDY_EDIT_DESC,
-        help="Edit a study description. \""
+        help='Edit a study description. "'
         + args.prog
         + " "
         + c_TOOL_STUDY_EDIT_DESC
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_edit_description.add_argument(
-        '--study-name',
+        "--study-name",
         required=True,
-        help='Name of the study for which to edit description.',
+        help="Name of the study for which to edit description.",
     )
     parser_edit_description.add_argument(
-        '--new-description',
+        "--new-description",
         required=True,
-        help='New description of the study to replace current one.',
+        help="New description of the study to replace current one.",
     )
 
     parser_edit_description.add_argument(
-        '--from-file',
-        action='store_true',
-        help='If true, assumes new_description argument is name pointing to file containing new_description.',
+        "--from-file",
+        action="store_true",
+        help="If true, assumes new_description argument is name pointing to file containing new_description.",
     )
 
     parser_edit_description.add_argument(
-        '--accept-html',
-        action='store_true',
-        help='If true, will allow HTML formatting in new description.',
+        "--accept-html",
+        action="store_true",
+        help="If true, will allow HTML formatting in new description.",
     )
 
     ## Create study get attribute subparser
     parser_get_attribute = subargs.add_parser(
         c_TOOL_STUDY_GET_ATTR,
-        help="Get a study attribute (such as cell_count, etc). \""
+        help='Get a study attribute (such as cell_count, etc). "'
         + args.prog
         + " "
         + c_TOOL_STUDY_GET_ATTR
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_get_attribute.add_argument(
-        '--study-name',
+        "--study-name",
         required=True,
-        help='Name of the study from which to get attribute.',
+        help="Name of the study from which to get attribute.",
     )
     parser_get_attribute.add_argument(
-        '--attribute',
+        "--attribute",
         required=True,
-        help='Attribute to return (such as cell_count, etc).',
+        help="Attribute to return (such as cell_count, etc).",
     )
 
     ## Create study get external resources subparser
     parser_get_ext_resources = subargs.add_parser(
         c_TOOL_STUDY_GET_EXT,
-        help="Get study external resources for a study. \""
+        help='Get study external resources for a study. "'
         + args.prog
         + " "
         + c_TOOL_STUDY_GET_EXT
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_get_ext_resources.add_argument(
-        '--study-name',
+        "--study-name",
         required=True,
-        help='Name of the study from which to get resources.',
+        help="Name of the study from which to get resources.",
     )
 
     ## Create study delete external resources subparser
     parser_delete_ext_resources = subargs.add_parser(
         c_TOOL_STUDY_DEL_EXT,
-        help="Delete all study external resources for a study. \""
+        help='Delete all study external resources for a study. "'
         + args.prog
         + " "
         + c_TOOL_STUDY_DEL_EXT
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_delete_ext_resources.add_argument(
-        '--study-name',
+        "--study-name",
         required=True,
-        help='Name of the study from which to delete resources.',
+        help="Name of the study from which to delete resources.",
     )
 
     ## Create study new external resource subparser
     parser_create_ext_resource = subargs.add_parser(
         c_TOOL_STUDY_CREATE_EXT,
-        help="Create a new external resource for a study. \""
+        help='Create a new external resource for a study. "'
         + args.prog
         + " "
         + c_TOOL_STUDY_CREATE_EXT
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_create_ext_resource.add_argument(
-        '--study-name',
+        "--study-name",
         required=True,
-        help='Name of the study to which to add resource.',
+        help="Name of the study to which to add resource.",
     )
     parser_create_ext_resource.add_argument(
-        '--title', required=True, help='Title of resource.',
+        "--title",
+        required=True,
+        help="Title of resource.",
     )
     parser_create_ext_resource.add_argument(
-        '--url', required=True, help='URL of resource.',
+        "--url",
+        required=True,
+        help="URL of resource.",
     )
     parser_create_ext_resource.add_argument(
-        '--description', required=True, help='Tooltip description of resource.',
+        "--description",
+        required=True,
+        help="Tooltip description of resource.",
     )
     parser_create_ext_resource.add_argument(
-        '--publication-url',
-        action='store_true',
-        help='Whether resource is publication URL.',
+        "--publication-url",
+        action="store_true",
+        help="Whether resource is publication URL.",
     )
     # TODO: Fix permissions subparser (SCP-2024)
     # ## Permissions subparser
@@ -242,63 +256,71 @@ def create_parser():
     ## Create cluster file upload subparser
     parser_upload_cluster = subargs.add_parser(
         c_TOOL_CLUSTER,
-        help="Upload a cluster file. \""
+        help='Upload a cluster file. "'
         + args.prog
         + " "
         + c_TOOL_CLUSTER
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_upload_cluster.add_argument(
-        '--file', dest='cluster_file', required=True, help='Cluster file to load.'
+        "--file", dest="cluster_file", required=True, help="Cluster file to load."
     )
     parser_upload_cluster.add_argument(
-        '--study-name', required=True, help='Name of the study to add the file.',
-    )
-    parser_upload_cluster.add_argument(
-        '--description',
-        default="Coordinates and optional metadata to visualize clusters.",
-        help='Text describing the cluster file.',
-    )
-    parser_upload_cluster.add_argument(
-        '--cluster-name',
+        "--study-name",
         required=True,
-        help='Name of the clustering that will be used to refer to the plot.',
+        help="Name of the study to add the file.",
     )
     parser_upload_cluster.add_argument(
-        '--x', dest='x_label', default=None, help='X axis label (test).'
+        "--description",
+        default="Coordinates and optional metadata to visualize clusters.",
+        help="Text describing the cluster file.",
     )
     parser_upload_cluster.add_argument(
-        '--y', dest='y_label', default=None, help='Y axis label (test).'
+        "--cluster-name",
+        required=True,
+        help="Name of the clustering that will be used to refer to the plot.",
     )
     parser_upload_cluster.add_argument(
-        '--z', dest='z_label', default=None, help='Z axis label (test).'
+        "--x", dest="x_label", default=None, help="X axis label (test)."
+    )
+    parser_upload_cluster.add_argument(
+        "--y", dest="y_label", default=None, help="Y axis label (test)."
+    )
+    parser_upload_cluster.add_argument(
+        "--z", dest="z_label", default=None, help="Z axis label (test)."
     )
 
     ## Create expression file upload subparser
     parser_upload_expression = subargs.add_parser(
         c_TOOL_EXPRESSION,
-        help="Upload a gene expression matrix file. \""
+        help='Upload a gene expression matrix file. "'
         + args.prog
         + " "
         + c_TOOL_EXPRESSION
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_upload_expression.add_argument(
-        '--file', dest='expression_file', required=True, help='Expression file to load.'
+        "--file", dest="expression_file", required=True, help="Expression file to load."
     )
     parser_upload_expression.add_argument(
-        '--study-name', required=True, help='Name of the study to add the file.',
+        "--study-name",
+        required=True,
+        help="Name of the study to add the file.",
     )
     parser_upload_expression.add_argument(
-        '--description',
-        default='Gene expression in cells',
-        help='Text describing the gene expression matrix file.',
+        "--description",
+        default="Gene expression in cells",
+        help="Text describing the gene expression matrix file.",
     )
     parser_upload_expression.add_argument(
-        '--species', required=True, help='Species from which the data is generated.',
+        "--species",
+        required=True,
+        help="Species from which the data is generated.",
     )
     parser_upload_expression.add_argument(
-        '--genome', required=True, help='Genome assembly used to generate the data.',
+        "--genome",
+        required=True,
+        help="Genome assembly used to generate the data.",
     )
     # TODO: Add upstream support for this in SCP RESI API
     # parser_upload_expression.add_argument(
@@ -310,29 +332,33 @@ def create_parser():
     ## Create metadata file upload subparser
     parser_upload_metadata = subargs.add_parser(
         c_TOOL_METADATA,
-        help="Upload a metadata file. \""
+        help='Upload a metadata file. "'
         + args.prog
         + " "
         + c_TOOL_METADATA
-        + " -h\" for more details",
+        + ' -h" for more details',
     )
     parser_upload_metadata.add_argument(
-        '--file', dest='metadata_file', required=True, help='Metadata file to load.'
+        "--file", dest="metadata_file", required=True, help="Metadata file to load."
     )
     parser_upload_metadata.add_argument(
-        '--use-convention',
-        help='Whether to use metadata convention: validates against standard vocabularies, and will enable faceted search on this data',
-        action='store_true',
+        "--use-convention",
+        help="Whether to use metadata convention: validates against standard vocabularies, and will enable faceted search on this data",
+        action="store_true",
     )
     parser_upload_metadata.add_argument(
-        '--validate-against-convention',
-        help='Validates against standard vocabularies prior to upload',
-        action='store_true',
+        "--validate-against-convention",
+        help="Validates against standard vocabularies prior to upload",
+        action="store_true",
     )
     parser_upload_metadata.add_argument(
-        '--study-name', required=True, help='Name of the study to add the file.',
+        "--study-name",
+        required=True,
+        help="Name of the study to add the file.",
     )
     parser_upload_metadata.add_argument(
-        '--description', default='', help='Text describing the metadata file.',
+        "--description",
+        default="",
+        help="Text describing the metadata file.",
     )
     return args

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -133,13 +133,7 @@ def login(parsed_args, manager=None, dry_run=False, api_base=None, verbose=False
     if manager is None:
         manager = scp_api.SCPAPIManager(verbose=verbose)
         if parsed_args.user_agent:
-            ingest_pkg_version = pkg_resources.get_distribution(
-                "scp-ingest-pipeline"
-            ).version
-            portal_pkg_version = pkg_resources.get_distribution(
-                "single_cell_portal"
-            ).version
-            user_agent = f"single-cell-portal/{portal_pkg_version} (manage-study) scp-ingest-pipeline/{ingest_pkg_version} (ingest_pipeline.py)"
+            user_agent = get_user_agent()
             manager.login(
                 token=parsed_args.token,
                 dry_run=dry_run,
@@ -149,6 +143,24 @@ def login(parsed_args, manager=None, dry_run=False, api_base=None, verbose=False
         else:
             manager.login(token=parsed_args.token, dry_run=dry_run, api_base=api_base)
     return manager
+
+
+def get_user_agent():
+    """Generate User-Agent string to reflect locally installed package versions"""
+    try:
+        ingest_pkg_version = pkg_resources.get_distribution(
+            "scp-ingest-pipeline"
+        ).version
+    except pkg_resources.DistributionNotFound:
+        ingest_pkg_version = None
+    try:
+        portal_pkg_version = pkg_resources.get_distribution(
+            "single_cell_portal"
+        ).version
+    except pkg_resources.DistributionNotFound:
+        portal_pkg_version = None
+    user_agent = f"single-cell-portal/{portal_pkg_version} (manage-study) scp-ingest-pipeline/{ingest_pkg_version} (ingest_pipeline.py)"
+    return user_agent
 
 
 def download_from_bucket(file_path):

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -53,6 +53,10 @@ python3 manage_study.py --token-$ACCESS_TOKEN create-study-external-resource --s
 
 # Print a study attribute (eg. cell_count)
 python3 manage_study.py --token-$ACCESS_TOKEN get-study-attribute --study-name "${STUDY_NAME}" --attribute cell_count
+
+# Avoid sending a user-agent string while obtaining the number of studies in SCP
+python manage_study.py --no-user-agent --token=$ACCESS_TOKEN list-studies --summary
+
 """
 
 import argparse
@@ -128,7 +132,7 @@ def login(parsed_args, manager=None, dry_run=False, api_base=None, verbose=False
     """
     if manager is None:
         manager = scp_api.SCPAPIManager(verbose=verbose)
-        if parsed_args.check_version:
+        if parsed_args.user_agent:
             ingest_pkg_version = pkg_resources.get_distribution(
                 "scp-ingest-pipeline"
             ).version
@@ -417,10 +421,10 @@ def main():
 
     ## Upload metadata file
     if hasattr(parsed_args, "metadata_file"):
+        connection = login(parsed_args, manager=connection, dry_run=parsed_args.dry_run)
         if verbose:
             print("START UPLOAD METADATA FILE")
-        connection = login(parsed_args, manager=connection, dry_run=parsed_args.dry_run)
-        print(f"connection is {connection}")
+            print(f"connection is {connection}")
         ret = connection.upload_metadata(
             file=parsed_args.metadata_file,
             use_convention=parsed_args.use_convention,

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -286,10 +286,9 @@ class APIManager:
                 print("\tgcloud auth login")
                 print("\tACCESS_TOKEN=`gcloud auth print-access-token`")
                 print("")
-            incompatible_ingest_version = re.search(
+            if ret.status_code == 400 and re.search(
                 "scp-ingest-pipeline.*incompatible", ret.json()["error"]
-            )
-            if ret.status_code == 400 and incompatible_ingest_version:
+            ):
                 print("")
                 print("Local ingest pipeline package version incompatibile with server")
                 print(ret.json()["error"])

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -285,6 +285,13 @@ class APIManager:
                 print("\tgcloud auth login")
                 print("\tACCESS_TOKEN=`gcloud auth print-access-token`")
                 print("")
+            if ret.status_code == 400 and re.search(
+                "scp-ingest-pipeline.*incompatible", ret.reason
+            ):
+                print("")
+                print("Ingest pipeline package version incompatibility with server?")
+                print("")
+                exit(1)
         api_return[c_CODE_RET_KEY] = ret.status_code
         api_return[c_RESPONSE] = ret
         return api_return

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -13,6 +13,7 @@ import random
 import string
 import os
 import json
+import re
 
 import logging
 
@@ -285,11 +286,13 @@ class APIManager:
                 print("\tgcloud auth login")
                 print("\tACCESS_TOKEN=`gcloud auth print-access-token`")
                 print("")
-            if ret.status_code == 400 and re.search(
-                "scp-ingest-pipeline.*incompatible", ret.reason
-            ):
+            incompatible_ingest_version = re.search(
+                "scp-ingest-pipeline.*incompatible", ret.json()["error"]
+            )
+            if ret.status_code == 400 and incompatible_ingest_version:
                 print("")
-                print("Ingest pipeline package version incompatibility with server?")
+                print("Local ingest pipeline package version incompatibile with server")
+                print(ret.json()["error"])
                 print("")
                 exit(1)
         api_return[c_CODE_RET_KEY] = ret.status_code
@@ -403,6 +406,7 @@ class SCPAPIManager(APIManager):
         else:
             if resp[c_SUCCESS_RET_KEY]:
                 studies_json = resp[c_RESPONSE].json()
+                print(f"from scp_api {studies_json}")
                 self.study_objects = studies_json
                 self.studies = [str(element["name"]) for element in studies_json]
                 self.name_to_id = [

--- a/scripts/tests/test_scp_api.py
+++ b/scripts/tests/test_scp_api.py
@@ -5,19 +5,21 @@ import json
 import re
 
 import sys
-sys.path.append('.')
+
+sys.path.append(".")
 
 import scp_api
 
 # TODO: Incorporate into `test_upload_cluster`
 def mock_upload_via_gsutil(*args, **kwargs):
     gsutil_stat = {
-        'Content-Type': 'test/foo',
-        'Content-Length': '555',
-        'Generation': 'foo'
+        "Content-Type": "test/foo",
+        "Content-Length": "555",
+        "Generation": "foo",
     }
-    filename = 'fake_path.txt'
+    filename = "fake_path.txt"
     return [gsutil_stat, filename]
+
 
 # This method will be used by the mock to replace requests.get
 def mocked_requests_get(*args, **kwargs):
@@ -29,15 +31,16 @@ def mocked_requests_get(*args, **kwargs):
 
         def json(self):
             return self.json_data
-    
+
     url = args[0]
-    if url == 'https://singlecell.broadinstitute.org/single_cell/api/v1/studies':
-        with open('tests/data/studies.json') as f:
+    if url == "https://singlecell.broadinstitute.org/single_cell/api/v1/studies":
+        with open("tests/data/studies.json") as f:
             content = f.read()
         studies_json = json.loads(content, strict=False)
-        return MockResponse(studies_json, 200, reason='OK')
+        return MockResponse(studies_json, 200, reason="OK")
 
     return MockResponse(None, 404)
+
 
 # This method will be used by the mock to replace requests.post
 def mocked_requests_post(*args, **kwargs):
@@ -52,50 +55,60 @@ def mocked_requests_post(*args, **kwargs):
 
     url = args[0]
 
-    study_files_url_re = '/v1/studies/.*/study_files$'
+    study_files_url_re = "/v1/studies/.*/study_files$"
     if re.search(study_files_url_re, url):
-        with open('tests/data/study_files_post.json') as f:
+        with open("tests/data/study_files_post.json") as f:
             content = f.read()
         study_files_json = json.loads(content, strict=False)
-        return MockResponse(study_files_json, 200, reason='OK')
+        return MockResponse(study_files_json, 200, reason="OK")
 
-    parse_url_re = '/v1/studies/.*/study_files/.*/parse$'
+    parse_url_re = "/v1/studies/.*/study_files/.*/parse$"
     if re.search(parse_url_re, url):
         return MockResponse(None, 204)
 
     return MockResponse(None, 404)
 
-class SCPAPITestCase(unittest.TestCase):
 
-    @patch('requests.get', side_effect=mocked_requests_get)
+class SCPAPITestCase(unittest.TestCase):
+    @patch("requests.get", side_effect=mocked_requests_get)
     def test_get_studies(self, mocked_requests_get):
         manager = scp_api.SCPAPIManager()
-        manager.api_base = 'https://singlecell.broadinstitute.org/single_cell/api/v1/'
+        manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
         manager.verify_https = True
-        studies = manager.get_studies()['studies']
+        manager.head = {"Accept": "application/json"}
+        studies = manager.get_studies()["studies"]
         expected_studies = [
             " Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)",
-            "Study only for unit test"
+            "Study only for unit test",
         ]
         self.assertEqual(studies, expected_studies)
 
-    @patch('scp_api.SCPAPIManager.upload_via_gsutil', side_effect=mock_upload_via_gsutil)
-    @patch('requests.post', side_effect=mocked_requests_post)
-    @patch('requests.get', side_effect=mocked_requests_get)
-    def test_upload_cluster(self, mocked_requests_get, mocked_requests_post, mock_upload_via_gsutil):
+    @patch(
+        "scp_api.SCPAPIManager.upload_via_gsutil", side_effect=mock_upload_via_gsutil
+    )
+    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("requests.get", side_effect=mocked_requests_get)
+    def test_upload_cluster(
+        self, mocked_requests_get, mocked_requests_post, mock_upload_via_gsutil
+    ):
         # manager = scp_api.SCPAPIManager(verbose=True)
         manager = scp_api.SCPAPIManager()
-        manager.api_base = 'https://singlecell.broadinstitute.org/single_cell/api/v1/'
+        manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
         manager.verify_https = True
         manager.login(dry_run=True)
-        return_object = manager.upload_cluster(file='../tests/data/toy_cluster',
-                                    study_name='Study only for unit test',
-                                    cluster_name='Test',
-                                    description='Test',
-                                    x='X', y='Y', z='Z')
+        return_object = manager.upload_cluster(
+            file="../tests/data/toy_cluster",
+            study_name="Study only for unit test",
+            cluster_name="Test",
+            description="Test",
+            x="X",
+            y="Y",
+            z="Z",
+        )
         # HTTP 204 indicates successful parse launch, per
         # https://singlecell.broadinstitute.org/single_cell/api/swagger_docs/v1#!/StudyFiles/parse_study_study_file_path
-        self.assertEqual(return_object['code'], 204)
+        self.assertEqual(return_object["code"], 204)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,27 @@
 from setuptools import setup, find_packages
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='single-cell-portal',
-    version='0.1.2',
-    description='Convenience scripts for Single Cell Portal',
+    name="single-cell-portal",
+    version="0.2.0",
+    description="Convenience scripts for Single Cell Portal",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/broadinstitute/single_cell_portal',
-    author='Single Cell Portal team',
-    author_email='scp-support@broadinstitute.zendesk.com',
-    install_requires=['pandas', 'requests', 'scp-ingest-pipeline==1.5.4'],
+    long_description_content_type="text/markdown",
+    url="https://github.com/broadinstitute/single_cell_portal",
+    author="Single Cell Portal team",
+    author_email="scp-support@broadinstitute.zendesk.com",
+    install_requires=["pandas", "requests", "scp-ingest-pipeline==1.5.4"],
     packages=find_packages(),
-    entry_points={'console_scripts': ['manage-study=scripts.manage_study:main'],},
+    entry_points={
+        "console_scripts": ["manage-study=scripts.manage_study:main"],
+    },
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: BSD License',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: BSD License",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "Programming Language :: Python :: 3.7",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Performing local validation against a metadata convention should give the same validation results as validation through an SCP server. In order to have consistent results, the code used for validation locally must match the code used on the remote server. To ensure the use of a consistent codebase, manage-study now transmits a user-agent string so the server can perform a validation check. If the local version of `scp-ingest-pipeline` does not match the version used on the server, the API request will be rejected.

This satisfies SCP-2415