### PR TITLE
Prevent file overwrite by manage-study (SCP-2698)

### DIFF
--- a/scripts/Commandline.py
+++ b/scripts/Commandline.py
@@ -7,6 +7,7 @@ import logging
 import os
 import subprocess as sp
 
+
 class Commandline:
     """
     This class wraps calls to the command line in a simple interface.
@@ -24,15 +25,10 @@ class Commandline:
 
         self.logr_cur = logr_cur if logr_cur else logging.getLogger(name)
 
-
     # Tested
-    def func_CMD(self,
-                 command,
-                 use_bash=False,
-                 test=False,
-                 stdout=False):
+    def func_CMD(self, command, use_bash=False, test=False, stdout=False, mute=False):
         """
-  	    Runs the given command.
+            Runs the given command.
         * command : Command to run on the commandline
                       : String
         * use_bash : Boolean
@@ -40,21 +36,22 @@ class Commandline:
                        BASH not SH (Bourne) or default shell (windows)
                      : Although the False is _I believe_ is not specific
                        to an OS, True is.
-	    * test : Boolean
-	               If true, the commands will not run but will be logged.
+            * test : Boolean
+                       If true, the commands will not run but will be logged.
         * stdout : Boolean
-                   : If true, stdout will be given instead of True.
+                     : If true, stdout will be given instead of True.
                      On a fail False (boolean) will still be given.
-	    * Return : Boolean
-	               True indicates success
-	      """
+        * mute : Boolean
+                     : If true, mute stdout even on fail False.
+            * Return : Boolean
+                       True indicates success
+        """
 
         return_code = None
 
         # Update command for bash shell
         if use_bash:
-            command = "".join([os.sep, "bin", os.sep,
-                                   "bash -c \'", command, "\'"])
+            command = "".join([os.sep, "bin", os.sep, "bash -c '", command, "'"])
 
         # Do not do anything when testing
         if test:
@@ -63,10 +60,9 @@ class Commandline:
         try:
             # Perform command and wait for completion
             if stdout:
-                subp_cur = sp.Popen(command,
-                                    shell=True,
-                                    cwd=os.getcwd(),
-                                    stdout=sp.PIPE)
+                subp_cur = sp.Popen(
+                    command, shell=True, cwd=os.getcwd(), stdout=sp.PIPE
+                )
             else:
                 subp_cur = sp.Popen(command, shell=True, cwd=os.getcwd())
             pid = str(subp_cur.pid)
@@ -80,28 +76,39 @@ class Commandline:
                 if stdout:
                     return out
                 return True
+            elif mute:
+                return False
             else:
-                self.logr_cur.error("".join([self.__class__.__name__,
-                                             "::Error::Received return code = ",
-                                             str(return_code)]))
-                self.logr_cur.error("".join([self.__class__.__name__,
-                                             "::Error::Command = ",
-                                             command]))
-                self.logr_cur.error("".join([self.__class__.__name__,
-                                             "::Error::Error out= ",
-                                             str(out)]))
-                self.logr_cur.error("".join([self.__class__.__name__,
-                                             "::Error::Error= ",
-                                             str(err)]))
+                self.logr_cur.error(
+                    "".join(
+                        [
+                            self.__class__.__name__,
+                            "::Error::Received return code = ",
+                            str(return_code),
+                        ]
+                    )
+                )
+                self.logr_cur.error(
+                    "".join([self.__class__.__name__, "::Error::Command = ", command])
+                )
+                self.logr_cur.error(
+                    "".join([self.__class__.__name__, "::Error::Error out= ", str(out)])
+                )
+                self.logr_cur.error(
+                    "".join([self.__class__.__name__, "::Error::Error= ", str(err)])
+                )
                 return False
 
         # Inform on errors:w
-        except(OSError, TypeError) as e:
-            self.logr_cur.error("".join([self.__class__.__name__,
-                                         "::Error::Fatal error."]))
-            self.logr_cur.error("".join([self.__class__.__name__,
-                                         "::Error::Command = ", command]))
-            self.logr_cur.error("".join([self.__class__.__name__,
-                                         "::Error:: Error = ", str(e)]))
+        except (OSError, TypeError) as e:
+            self.logr_cur.error(
+                "".join([self.__class__.__name__, "::Error::Fatal error."])
+            )
+            self.logr_cur.error(
+                "".join([self.__class__.__name__, "::Error::Command = ", command])
+            )
+            self.logr_cur.error(
+                "".join([self.__class__.__name__, "::Error:: Error = ", str(e)])
+            )
             return False
         return False

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -64,7 +64,7 @@ EXIT CODES
 82  exit-failed-to-gsutil-delete-file
 83  exit-uploaded-file-deleted
 84  exit-no-file-cleanup-needed
-
+85  exit-file-not-found-in-remote-bucket
 """
 
 import argparse

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -57,6 +57,14 @@ python3 manage_study.py --token-$ACCESS_TOKEN get-study-attribute --study-name "
 # Avoid sending a user-agent string while obtaining the number of studies in SCP
 python manage_study.py --no-user-agent --token=$ACCESS_TOKEN list-studies --summary
 
+EXIT CODES
+79  incompatible scp-ingest-pipeline package version detected
+80  exit-file-already-exists-in-study-bucket
+81  exit-file-not-found-in-study-bucket
+82  exit-failed-to-gsutil-delete-file
+83  exit-uploaded-file-deleted
+84  exit-no-file-cleanup-needed
+
 """
 
 import argparse

--- a/scripts/manage_study.py
+++ b/scripts/manage_study.py
@@ -58,6 +58,7 @@ python3 manage_study.py --token-$ACCESS_TOKEN get-study-attribute --study-name "
 python manage_study.py --no-user-agent --token=$ACCESS_TOKEN list-studies --summary
 
 EXIT CODES
+# TODO: replace with python error handling and logging (SCP-2790)
 79  incompatible scp-ingest-pipeline package version detected
 80  exit-file-already-exists-in-study-bucket
 81  exit-file-not-found-in-study-bucket

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -864,9 +864,14 @@ class SCPAPIManager(APIManager):
         print()
 
         # Upload to bucket via gsutil
-        if not file_from_study_bucket:
-            command = "gsutil cp " + file_path + " " + gs_url
-            cmdline.func_CMD(command=command, stdout=False)
+        if not file_from_study_bucket and source_bucket:
+            if SCPAPIManager.exists_in_bucket(file_path):
+                command = "gsutil cp " + file_path + " " + gs_url
+                cmdline.func_CMD(command=command, stdout=False)
+            else:
+                print(f"\nERROR: failed to find upload file {file_path}.")
+                # custom exit code to indicate exit-file-not-found-in-remote-bucket
+                exit(85)
 
         # Get GCS details for the file to be used
         command = "gsutil stat " + gs_url + "/" + filename

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -99,12 +99,6 @@ c_MATRIX_BAD_FORMAT_TEXT = "The requested format is not supported in the service
 cmdline = Commandline.Commandline()
 
 
-def exists_in_bucket(bucket_file_path, mute=False):
-    """gsutil gstat to see if file is in study bucket"""
-    command = "gsutil stat " + bucket_file_path
-    return cmdline.func_CMD(command=command, mute=True)
-
-
 class APIManager:
     """
     Base class for REST API interaction. Handles common operations.
@@ -826,7 +820,7 @@ class SCPAPIManager(APIManager):
     @staticmethod
     def exists_in_bucket(bucket_file_path, mute=False):
         """gsutil gstat to see if file is in study bucket"""
-        command = "gsutil ls " + bucket_file_path
+        command = "gsutil stat " + bucket_file_path
         return cmdline.func_CMD(command=command, mute=True)
 
     @staticmethod
@@ -864,10 +858,10 @@ class SCPAPIManager(APIManager):
         print()
 
         # Upload to bucket via gsutil
-        if not file_from_study_bucket and source_bucket:
-            if SCPAPIManager.exists_in_bucket(file_path):
-                command = "gsutil cp " + file_path + " " + gs_url
-                cmdline.func_CMD(command=command, stdout=False)
+        if not (file_from_study_bucket and source_bucket):
+            command = "gsutil cp " + file_path + " " + gs_url
+            if cmdline.func_CMD(command=command, stdout=False):
+                print("\n")
             else:
                 print(f"\nERROR: failed to find upload file {file_path}.")
                 # custom exit code to indicate exit-file-not-found-in-remote-bucket

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -99,6 +99,12 @@ c_MATRIX_BAD_FORMAT_TEXT = "The requested format is not supported in the service
 cmdline = Commandline.Commandline()
 
 
+def exists_in_bucket(bucket_file_path, mute=False):
+    """gsutil gstat to see if file is in study bucket"""
+    command = "gsutil stat " + bucket_file_path
+    return cmdline.func_CMD(command=command, mute=True)
+
+
 class APIManager:
     """
     Base class for REST API interaction. Handles common operations.
@@ -829,9 +835,8 @@ class SCPAPIManager(APIManager):
             source_bucket = None
 
         # check if file in bucket via gsutil
-        command = "gsutil stat " + gs_url + "/" + filename
-        print("Checking if file already exists in study bucket.")
-        if cmdline.func_CMD(command=command, mute=True):
+        full_gs_url = gs_url + "/" + filename
+        if exists_in_bucket(full_gs_url, mute=True):
             if source_bucket == bucket_id:
                 print(f"Using existing file, {filename}, in study bucket.")
                 file_from_study_bucket = True

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -295,6 +295,7 @@ class APIManager:
                 print("")
                 # custom exit code to indicate
                 # incompatible scp-ingest-pipeline package version detected
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(79)
         api_return[c_CODE_RET_KEY] = ret.status_code
         api_return[c_RESPONSE] = ret
@@ -847,11 +848,13 @@ class SCPAPIManager(APIManager):
                     f"ERROR: {filename} already exists in study bucket, please delete existing file, then retry."
                 )
                 # custom exit code to indicate exit-file-already-exists-in-study-bucket
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(80)
         else:
             if source_bucket == bucket_id:
                 print(f"\nERROR: {filename} not found in study bucket.")
                 # custom exit code to indicate exit-file-not-found-in-study-bucket
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(81)
             else:
                 file_from_study_bucket = False
@@ -865,6 +868,7 @@ class SCPAPIManager(APIManager):
             else:
                 print(f"\nERROR: failed to find upload file {file_path}.")
                 # custom exit code to indicate exit-file-not-found-in-remote-bucket
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(85)
 
         # Get GCS details for the file to be used
@@ -893,6 +897,7 @@ class SCPAPIManager(APIManager):
         if not cmdline.func_CMD(command=command, stdout=False):
             print(f"ERROR: failed to delete {filename}.")
             # custom exit code to indicate exit-failed-to-gsutil-delete-file
+            # TODO: replace with python error handling and logging (SCP-2790)
             exit(82)
 
     def upload_study_file(
@@ -962,10 +967,12 @@ class SCPAPIManager(APIManager):
                 print("\nCleaning up after failed request:")
                 self.delete_via_gsutil(bucket_id, file)
                 # custom exit code to indicate exit-uploaded-file-deleted
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(83)
             else:
                 print("\nExisting file will persist in study bucket.")
                 # custom exit code to indicate exit-no-file-cleanup-needed
+                # TODO: replace with python error handling and logging (SCP-2790)
                 exit(84)
 
         if parse:

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -822,6 +822,12 @@ class SCPAPIManager(APIManager):
             return self.name_to_id.get(name, None)
 
     @staticmethod
+    def exists_in_bucket(bucket_file_path, mute=False):
+        """gsutil gstat to see if file is in study bucket"""
+        command = "gsutil stat " + bucket_file_path
+        return cmdline.func_CMD(command=command, mute=True)
+
+    @staticmethod
     def upload_via_gsutil(bucket_id, file_path):
         """Copy file to Google Cloud Storage bucket, return stats and filename"""
 
@@ -836,7 +842,7 @@ class SCPAPIManager(APIManager):
 
         # check if file in bucket via gsutil
         full_gs_url = gs_url + "/" + filename
-        if exists_in_bucket(full_gs_url, mute=True):
+        if SCPAPIManager.exists_in_bucket(full_gs_url, mute=True):
             if source_bucket == bucket_id:
                 print(f"Using existing file, {filename}, in study bucket.")
                 file_from_study_bucket = True

--- a/scripts/scp_api.py
+++ b/scripts/scp_api.py
@@ -299,7 +299,9 @@ class APIManager:
                 print("Local ingest pipeline package version incompatibile with server")
                 print(ret.json()["error"])
                 print("")
-                exit(1)
+                # custom exit code to indicate
+                # incompatible scp-ingest-pipeline package version detected
+                exit(79)
         api_return[c_CODE_RET_KEY] = ret.status_code
         api_return[c_RESPONSE] = ret
         return api_return
@@ -824,7 +826,7 @@ class SCPAPIManager(APIManager):
     @staticmethod
     def exists_in_bucket(bucket_file_path, mute=False):
         """gsutil gstat to see if file is in study bucket"""
-        command = "gsutil stat " + bucket_file_path
+        command = "gsutil ls " + bucket_file_path
         return cmdline.func_CMD(command=command, mute=True)
 
     @staticmethod
@@ -850,11 +852,13 @@ class SCPAPIManager(APIManager):
                 print(
                     f"ERROR: {filename} already exists in study bucket, please delete existing file, then retry."
                 )
-                exit(1)
+                # custom exit code to indicate exit-file-already-exists-in-study-bucket
+                exit(80)
         else:
             if source_bucket == bucket_id:
                 print(f"\nERROR: {filename} not found in study bucket.")
-                exit(1)
+                # custom exit code to indicate exit-file-not-found-in-study-bucket
+                exit(81)
             else:
                 file_from_study_bucket = False
         print()
@@ -889,7 +893,8 @@ class SCPAPIManager(APIManager):
 
         if not cmdline.func_CMD(command=command, stdout=False):
             print(f"ERROR: failed to delete {filename}.")
-            exit(1)
+            # custom exit code to indicate exit-failed-to-gsutil-delete-file
+            exit(82)
 
     def upload_study_file(
         self,
@@ -957,9 +962,12 @@ class SCPAPIManager(APIManager):
             if not file_from_study_bucket:
                 print("\nCleaning up after failed request:")
                 self.delete_via_gsutil(bucket_id, file)
+                # custom exit code to indicate exit-uploaded-file-deleted
+                exit(83)
             else:
                 print("\nExisting file will persist in study bucket.")
-            exit(1)
+                # custom exit code to indicate exit-no-file-cleanup-needed
+                exit(84)
 
         if parse:
             study_files_response = ret["response"].json()

--- a/scripts/tests/test_scp_api.py
+++ b/scripts/tests/test_scp_api.py
@@ -11,7 +11,7 @@ sys.path.append(".")
 import scp_api
 
 # TODO: Incorporate into `test_upload_cluster`
-def mock_upload_via_gsutil(*args, **kwargs):
+def mock_upload_via_gsutil_study_bucket_true(*args, **kwargs):
     gsutil_stat = {
         "Content-Type": "test/foo",
         "Content-Length": "555",
@@ -22,8 +22,15 @@ def mock_upload_via_gsutil(*args, **kwargs):
     return [gsutil_stat, filename, file_from_study_bucket]
 
 
-def mock_exists_in_bucket(*args, **kwargs):
-    return True
+def mock_upload_via_gsutil_study_bucket_false(*args, **kwargs):
+    gsutil_stat = {
+        "Content-Type": "test/foo",
+        "Content-Length": "555",
+        "Generation": "foo",
+    }
+    filename = "fake_path.txt"
+    file_from_study_bucket = False
+    return [gsutil_stat, filename, file_from_study_bucket]
 
 
 # This method will be used by the mock to replace requests.get
@@ -44,6 +51,15 @@ def mocked_requests_get(*args, **kwargs):
         studies_json = json.loads(content, strict=False)
         return MockResponse(studies_json, 200, reason="OK")
 
+    if (
+        url
+        == "https://singlecell.broadinstitute.org/single_cell/api/v1/studies/11114a35421aa904f7922101"
+    ):
+        ingest_mismatch_json = {
+            "error": 'scp-ingest-pipeline: 0.9.12 incompatible with host, please update via "pip install scp-ingest-pipeline --upgrade"'
+        }
+        return MockResponse(ingest_mismatch_json, 400)
+
     return MockResponse(None, 404)
 
 
@@ -59,7 +75,8 @@ def mocked_requests_post(*args, **kwargs):
             return self.json_data
 
     url = args[0]
-
+    # study_id for " Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)"
+    # is 577d4a35421aa904f7922101
     upload_existing_file_url = "/v1/studies/577d4a35421aa904f7922101/study_files$"
     if re.search(upload_existing_file_url, url):
         unprocessable_entity_json = {
@@ -81,24 +98,6 @@ def mocked_requests_post(*args, **kwargs):
     return MockResponse(None, 404)
 
 
-# This method will be used by the mock to replace requests.get response
-# for ingest pipeline major version mismatch response in user-agent string
-def mocked_ingest_version_mismatch(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code, reason=None):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.reason = reason
-
-        def json(self):
-            return self.json_data
-
-    ingest_mismatch_json = {
-        "error": 'scp-ingest-pipeline: 0.9.12 incompatible with host, please update via "pip install scp-ingest-pipeline --upgrade"'
-    }
-    return MockResponse(ingest_mismatch_json, 400)
-
-
 class SCPAPITestCase(unittest.TestCase):
     @patch("requests.get", side_effect=mocked_requests_get)
     def test_get_studies(self, mocked_requests_get):
@@ -113,7 +112,7 @@ class SCPAPITestCase(unittest.TestCase):
         ]
         self.assertEqual(studies, expected_studies)
 
-    @patch("requests.get", side_effect=mocked_ingest_version_mismatch)
+    @patch("requests.get", side_effect=mocked_requests_get)
     def test_ingest_version_mismatch(self, mocked_ingest_version_mismatch):
         manager = scp_api.SCPAPIManager()
         manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
@@ -123,43 +122,91 @@ class SCPAPITestCase(unittest.TestCase):
             "User-Agent": "single-cell-portal/0.1.3rc1 (manage-study) scp-ingest-pipeline/0.9.12 (ingest_pipeline.py)",
         }
 
+        # All SCP servers use single-cell-portal major release v1 or later, sending
+        # User-Agent string with an outdated package version should fail
         with self.assertRaises(SystemExit) as cm:
-            manager.get_studies()["studies"]
-
+            manager.get_study_attribute(
+                study_name="Study only for unit test", attribute="accession"
+            )
+        # 400 "incompatibile with server" response should trigger custom exit code 79
         self.assertEqual(
-            cm.exception.code, 1
+            cm.exception.code, 79
         ), "expect exit if ingest major version mismatch detected"
 
     @patch(
-        "scp_api.exists_in_bucket",
-        side_effect=mock_exists_in_bucket,
+        "scp_api.SCPAPIManager.exists_in_bucket",
+        return_value=True,
     )
-    def test_upload_existing_file(self, mock_exists_in_bucket):
+    def test_upload_via_gsutil_remote_preexists(self, mock_exists_in_bucket):
+
+        with self.assertRaises(SystemExit) as cm:
+            scp_api.SCPAPIManager.upload_via_gsutil(
+                bucket_id="foo", file_path="gs://baz/bar"
+            )
+        # If exists_in_bucket is True, exit-file-already-exists-in-study-bucket
+        self.assertEqual(
+            cm.exception.code, 80
+        ), "expect exit if filename of remote file also exists in study bucket"
+
+    @patch(
+        "scp_api.SCPAPIManager.exists_in_bucket",
+        return_value=False,
+    )
+    def test_upload_via_gsutil_missing_in_study_bucket(self, mock_exists_in_bucket):
+
+        with self.assertRaises(SystemExit) as cm:
+            scp_api.SCPAPIManager.upload_via_gsutil(
+                bucket_id="foo", file_path="gs://foo/bar"
+            )
+        # If filepath uses study bucket but file is missing, expect exit
+        self.assertEqual(
+            cm.exception.code, 81
+        ), "expect exit if file does not exists in study bucket"
+
+    @patch(
+        "scp_api.SCPAPIManager.upload_via_gsutil",
+        side_effect=mock_upload_via_gsutil_study_bucket_true,
+    )
+    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("requests.get", side_effect=mocked_requests_get)
+    def test_upload_unprocessable_entity_study_bucket_true(
+        self,
+        mock_upload_via_gsutil_study_bucket_true,
+        mocked_requests_post,
+        mocked_requests_get,
+    ):
         manager = scp_api.SCPAPIManager()
         manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
         manager.verify_https = True
         manager.login(dry_run=True)
 
+        # 422 response (unprocessable entity) from server
+        # causes script to exit during file upload request
         with self.assertRaises(SystemExit) as cm:
-            manager.return_object = manager.upload_via_gsutil(
-                bucket_id="foo", file_path="gs://baz/bar"
+            manager.upload_study_file(
+                file="fc-36f39ea7-1111-4a49-ad10-6a5a4614300e/foo.txt",
+                file_type="Metadata",
+                study_name=" Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)",
             )
-
-        self.assertEqual(
-            cm.exception.code, 1
-        ), "expect exit if filename of remote file also exists in study bucket"
-
-        # manager.upload_via_gsutil(
-        #     bucket_id="foo", file_path="gs://foo/bar"
-        # )
+        # when file_from_study_bucket = True, no cleanup in bucket occurs
+        self.assertEqual(cm.exception.code, 84), "expect exit-no-file-cleanup-needed"
 
     @patch(
-        "scp_api.SCPAPIManager.upload_via_gsutil", side_effect=mock_upload_via_gsutil
+        "scp_api.SCPAPIManager.upload_via_gsutil",
+        side_effect=mock_upload_via_gsutil_study_bucket_false,
     )
     @patch("requests.post", side_effect=mocked_requests_post)
     @patch("requests.get", side_effect=mocked_requests_get)
-    def test_upload_unprocessable_entity(
-        self, mock_upload_via_gsutil, mocked_requests_post, mocked_requests_get
+    @patch(
+        "scp_api.SCPAPIManager.delete_via_gsutil",
+        return_value=True,
+    )
+    def test_upload_unprocessable_entity_study_bucket_false(
+        self,
+        mocked_requests_get,
+        mocked_requests_post,
+        mock_upload_via_gsutil_study_bucket_false,
+        mock_delete_via_gsutil,
     ):
         manager = scp_api.SCPAPIManager()
         manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
@@ -168,19 +215,24 @@ class SCPAPITestCase(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as cm:
             manager.upload_study_file(
-                file="foo.txt",
+                file="gs://fc-36f39ea7-439e-4a49-ad10-6a5a4614300e/metadata.txt",
                 file_type="Metadata",
                 study_name=" Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)",
             )
-        self.assertEqual(cm.exception.code, 1), "expect exit on status code 422"
+        # when file_from_study_bucket = True, uploaded file is deleted from study bucket
+        self.assertEqual(cm.exception.code, 83), "expect exit-uploaded-file-deleted"
 
     @patch(
-        "scp_api.SCPAPIManager.upload_via_gsutil", side_effect=mock_upload_via_gsutil
+        "scp_api.SCPAPIManager.upload_via_gsutil",
+        side_effect=mock_upload_via_gsutil_study_bucket_true,
     )
     @patch("requests.post", side_effect=mocked_requests_post)
     @patch("requests.get", side_effect=mocked_requests_get)
     def test_upload_cluster(
-        self, mocked_requests_get, mocked_requests_post, mock_upload_via_gsutil
+        self,
+        mocked_requests_get,
+        mocked_requests_post,
+        mock_upload_via_gsutil_study_bucket_true,
     ):
         # manager = scp_api.SCPAPIManager(verbose=True)
         manager = scp_api.SCPAPIManager()

--- a/scripts/tests/test_scp_api.py
+++ b/scripts/tests/test_scp_api.py
@@ -18,7 +18,12 @@ def mock_upload_via_gsutil(*args, **kwargs):
         "Generation": "foo",
     }
     filename = "fake_path.txt"
-    return [gsutil_stat, filename]
+    file_from_study_bucket = True
+    return [gsutil_stat, filename, file_from_study_bucket]
+
+
+def mock_exists_in_bucket(*args, **kwargs):
+    return True
 
 
 # This method will be used by the mock to replace requests.get
@@ -54,6 +59,13 @@ def mocked_requests_post(*args, **kwargs):
             return self.json_data
 
     url = args[0]
+
+    upload_existing_file_url = "/v1/studies/577d4a35421aa904f7922101/study_files$"
+    if re.search(upload_existing_file_url, url):
+        unprocessable_entity_json = {
+            "errors": {"file_type": ["You may only add one metadata file per study"]}
+        }
+        return MockResponse(unprocessable_entity_json, 422)
 
     study_files_url_re = "/v1/studies/.*/study_files$"
     if re.search(study_files_url_re, url):
@@ -117,6 +129,50 @@ class SCPAPITestCase(unittest.TestCase):
         self.assertEqual(
             cm.exception.code, 1
         ), "expect exit if ingest major version mismatch detected"
+
+    @patch(
+        "scp_api.exists_in_bucket",
+        side_effect=mock_exists_in_bucket,
+    )
+    def test_upload_existing_file(self, mock_exists_in_bucket):
+        manager = scp_api.SCPAPIManager()
+        manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
+        manager.verify_https = True
+        manager.login(dry_run=True)
+
+        with self.assertRaises(SystemExit) as cm:
+            manager.return_object = manager.upload_via_gsutil(
+                bucket_id="foo", file_path="gs://baz/bar"
+            )
+
+        self.assertEqual(
+            cm.exception.code, 1
+        ), "expect exit if filename of remote file also exists in study bucket"
+
+        # manager.upload_via_gsutil(
+        #     bucket_id="foo", file_path="gs://foo/bar"
+        # )
+
+    @patch(
+        "scp_api.SCPAPIManager.upload_via_gsutil", side_effect=mock_upload_via_gsutil
+    )
+    @patch("requests.post", side_effect=mocked_requests_post)
+    @patch("requests.get", side_effect=mocked_requests_get)
+    def test_upload_unprocessable_entity(
+        self, mock_upload_via_gsutil, mocked_requests_post, mocked_requests_get
+    ):
+        manager = scp_api.SCPAPIManager()
+        manager.api_base = "https://singlecell.broadinstitute.org/single_cell/api/v1/"
+        manager.verify_https = True
+        manager.login(dry_run=True)
+
+        with self.assertRaises(SystemExit) as cm:
+            manager.upload_study_file(
+                file="foo.txt",
+                file_type="Metadata",
+                study_name=" Single nucleus RNA-seq of cell diversity in the adult mouse hippocampus (sNuc-Seq)",
+            )
+        self.assertEqual(cm.exception.code, 1), "expect exit on status code 422"
 
     @patch(
         "scp_api.SCPAPIManager.upload_via_gsutil", side_effect=mock_upload_via_gsutil

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="single-cell-portal",
-    version="0.2.0",
+    version="0.2.1",
     description="Convenience scripts for Single Cell Portal",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Currently manage-study uploads files before performing ingest without checking if a file of the same name already exists in the study bucket. manage-study should not overwrite existing, valid study files.

With this update, manage-study handles file upload more appropriately with the follow behaviors:
1. checks that no file with the upload file name exists in the google bucket
2. checks that file paths for upload from google buckets are vaild
3. removes file copied for upload if upload request is refused (422 status code)
4. if upload request for file pre-existing in study bucket, does not perform cleanup (#3 above)
5. handles 422 server response appropriately (either 3 or 4 above)

This fulfills SCP-2698.