### PR TITLE
increment for PyPI release (SCP-2840)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open("README.md", "r") as fh:
 
 setup(
     name="single-cell-portal",
-    version="0.2.1",
+    version="0.2.2",
     description="Convenience scripts for Single Cell Portal",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/broadinstitute/single_cell_portal",
     author="Single Cell Portal team",
     author_email="scp-support@broadinstitute.zendesk.com",
-    install_requires=["pandas", "requests", "scp-ingest-pipeline==1.5.4"],
+    install_requires=["pandas", "requests", "scp-ingest-pipeline==1.7.0"],
     packages=find_packages(),
     entry_points={
         "console_scripts": ["manage-study=scripts.manage_study:main"],


### PR DESCRIPTION
PyPI release to update manage-study to use scp-ingest-pipeline release 1.7.0

This supports SCP-2840.