### PR TITLE
Updating to scp-ingest-pipeline 1.11.0 (SCP-3414)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=0.16.2
 requests>=2.21.0
-scp-ingest-pipeline==1.7.0
+scp-ingest-pipeline==1.11.0
 
 # For faster development iterations.
 # ../../scp-ingest-pipeline

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="single-cell-portal",
-    version="0.2.2",
+    version="0.3.0",
     description="Convenience scripts for Single Cell Portal",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://github.com/broadinstitute/single_cell_portal",
     author="Single Cell Portal team",
     author_email="scp-support@broadinstitute.zendesk.com",
-    install_requires=["pandas", "requests", "scp-ingest-pipeline==1.7.0"],
+    install_requires=["pandas", "requests", "scp-ingest-pipeline==1.11.0"],
     packages=find_packages(),
     entry_points={
         "console_scripts": ["manage-study=scripts.manage_study:main"],


### PR DESCRIPTION
Updating the version of `scp-ingest-pipeline` to `1.11.0` and incrementing the local version of `single-cell-portal` to `0.3.0`.